### PR TITLE
perf: encode shared constraints with an auxiliary variable per version set

### DIFF
--- a/src/conflict.rs
+++ b/src/conflict.rs
@@ -13,7 +13,7 @@ use petgraph::{
 
 use crate::{
     DenseIndex, DependencyProvider, Interner, Requirement, SolvableId, SolverId, StringId,
-    VersionSetId,
+    VariableId, VersionSetId,
     internal::{id::ClauseId, solver_id::SolvableIdOrRoot},
     runtime::AsyncRuntime,
     solver::{Solver, clause::Clause, variable_map::VariableOrigin},
@@ -55,6 +55,72 @@ impl Conflict {
         let root_node = Self::add_node(&mut graph, &mut nodes, SolvableIdOrRoot::root());
         let unresolved_node = graph.add_node(ConflictNode::UnresolvedDependency);
         let mut last_node_by_name: HashMap<D::NameId, NodeIndex> = HashMap::default();
+
+        // The shared constrains encoding splits each (parent, excluded
+        // candidate) pair over two clauses linked by an auxiliary variable.
+        // Collect both sides per auxiliary variable so the original
+        // `parent -> candidate` edges can be reconstructed in the loop below.
+        let mut constrains_aux_parents: HashMap<VariableId, Vec<SolvableIdOrRoot<D::SolvableId>>> =
+            HashMap::default();
+        let mut constrains_aux_candidates: HashMap<
+            VariableId,
+            Vec<SolvableIdOrRoot<D::SolvableId>>,
+        > = HashMap::default();
+        for clause_id in &self.clauses {
+            match state.clauses.kinds[clause_id.to_index()] {
+                Clause::ConstrainsParent(parent, aux, _) => {
+                    let parent = parent
+                        .as_solvable_or_root(&state.variable_map)
+                        .expect("constrains parents are solvables or root");
+                    constrains_aux_parents.entry(aux).or_default().push(parent);
+                }
+                Clause::ConstrainsExcluded(candidate, aux, _) => {
+                    let candidate = candidate
+                        .as_solvable_or_root(&state.variable_map)
+                        .expect("excluded candidates are solvables");
+                    constrains_aux_candidates
+                        .entry(aux)
+                        .or_default()
+                        .push(candidate);
+                }
+                _ => {}
+            }
+        }
+
+        // If only one side of a chain is part of the conflict, recover the
+        // other side from the assignment reason of the auxiliary variable.
+        let reason_clause = |aux: VariableId| {
+            state
+                .decision_tracker
+                .find_clause_for_assignment(aux)
+                .map(|clause_id| state.clauses.kinds[clause_id.to_index()])
+        };
+        for &aux in constrains_aux_parents.keys() {
+            if constrains_aux_candidates.contains_key(&aux) {
+                continue;
+            }
+            if let Some(Clause::ConstrainsExcluded(candidate, _, _)) = reason_clause(aux) {
+                let candidate = candidate
+                    .as_solvable_or_root(&state.variable_map)
+                    .expect("excluded candidates are solvables");
+                constrains_aux_candidates.insert(aux, vec![candidate]);
+            }
+        }
+        for &aux in constrains_aux_candidates.keys() {
+            if constrains_aux_parents.contains_key(&aux) {
+                continue;
+            }
+            if let Some(Clause::ConstrainsParent(parent, _, _)) = reason_clause(aux) {
+                let parent = parent
+                    .as_solvable_or_root(&state.variable_map)
+                    .expect("constrains parents are solvables or root");
+                constrains_aux_parents.insert(aux, vec![parent]);
+            }
+        }
+
+        // Avoids adding the same edge once for each side of a chain.
+        type ConstrainsEdge<S> = (SolvableIdOrRoot<S>, SolvableIdOrRoot<S>, VersionSetId);
+        let mut constrains_edges: HashSet<ConstrainsEdge<D::SolvableId>> = HashSet::new();
 
         for clause_id in &self.clauses {
             let clause = &state.clauses.kinds[clause_id.to_index()];
@@ -159,6 +225,62 @@ impl Conflict {
                         dep_node,
                         ConflictEdge::Conflict(ConflictCause::Constrains(version_set_id)),
                     );
+                }
+                &Clause::ConstrainsParent(package_id, aux, version_set_id) => {
+                    let package_solvable = package_id
+                        .as_solvable_or_root(&state.variable_map)
+                        .expect("constrains parents are solvables or root");
+
+                    let Some(candidates) = constrains_aux_candidates.get(&aux) else {
+                        continue;
+                    };
+
+                    for &dependency_solvable in candidates {
+                        if !constrains_edges.insert((
+                            package_solvable,
+                            dependency_solvable,
+                            version_set_id,
+                        )) {
+                            continue;
+                        }
+
+                        let package_node = Self::add_node(&mut graph, &mut nodes, package_solvable);
+                        let dep_node = Self::add_node(&mut graph, &mut nodes, dependency_solvable);
+
+                        graph.add_edge(
+                            package_node,
+                            dep_node,
+                            ConflictEdge::Conflict(ConflictCause::Constrains(version_set_id)),
+                        );
+                    }
+                }
+                &Clause::ConstrainsExcluded(dep_id, aux, version_set_id) => {
+                    let dependency_solvable = dep_id
+                        .as_solvable_or_root(&state.variable_map)
+                        .expect("excluded candidates are solvables");
+
+                    let Some(parents) = constrains_aux_parents.get(&aux) else {
+                        continue;
+                    };
+
+                    for &package_solvable in parents {
+                        if !constrains_edges.insert((
+                            package_solvable,
+                            dependency_solvable,
+                            version_set_id,
+                        )) {
+                            continue;
+                        }
+
+                        let package_node = Self::add_node(&mut graph, &mut nodes, package_solvable);
+                        let dep_node = Self::add_node(&mut graph, &mut nodes, dependency_solvable);
+
+                        graph.add_edge(
+                            package_node,
+                            dep_node,
+                            ConflictEdge::Conflict(ConflictCause::Constrains(version_set_id)),
+                        );
+                    }
                 }
                 Clause::AnyOf(selected, _variable) => {
                     // Assumption: since `AnyOf` of clause can never be false, we dont add an edge

--- a/src/solver/clause.rs
+++ b/src/solver/clause.rs
@@ -81,6 +81,30 @@ pub(crate) enum Clause<N> {
     ///
     /// In SAT terms: (¬A ∨ ¬B)
     Constrains(VariableId, VariableId, VersionSetId),
+    /// Makes the constraint's auxiliary variable turn true when a candidate
+    /// that is excluded by the constraint's version set is installed.
+    ///
+    /// Usage: constraints whose version set excludes many candidates share a
+    /// single auxiliary variable per version set. The clauses that link the
+    /// excluded candidates to the auxiliary variable are emitted once per
+    /// version set, and each (parent, version set) pair only adds a single
+    /// [`Clause::ConstrainsParent`] clause. Together these encode the same
+    /// restriction as [`Clause::Constrains`] with O(candidates + parents)
+    /// instead of O(candidates * parents) clauses.
+    ///
+    /// Only this implication direction is needed (the Plaisted-Greenbaum
+    /// one-sided form): the auxiliary variable is never decided directly, it
+    /// only receives a value through propagation.
+    ///
+    /// In SAT terms: (¬candidate ∨ aux)
+    ConstrainsExcluded(VariableId, VariableId, VersionSetId),
+    /// Forbids a parent solvable from being installed together with the
+    /// constraint's auxiliary variable, i.e. together with any candidate that
+    /// is excluded by the constraint's version set. See
+    /// [`Clause::ConstrainsExcluded`] for an overview of the encoding.
+    ///
+    /// In SAT terms: (¬parent ∨ ¬aux)
+    ConstrainsParent(VariableId, VariableId, VersionSetId),
     /// Forbids the package on the right-hand side
     ///
     /// Note that the package on the left-hand side is not part of the clause,
@@ -117,6 +141,8 @@ impl<N> Clause<N> {
         matches!(
             self,
             Clause::Constrains(..)
+                | Clause::ConstrainsExcluded(..)
+                | Clause::ConstrainsParent(..)
                 | Clause::ForbidMultipleInstances(..)
                 | Clause::Lock(..)
                 | Clause::AnyOf(..)
@@ -218,6 +244,44 @@ impl<N: SolverId> Clause<N> {
         )
     }
 
+    /// Returns the building blocks needed for a new [WatchedLiterals] of the
+    /// [Clause::ConstrainsExcluded] kind.
+    fn constrains_excluded(
+        candidate: VariableId,
+        aux: VariableId,
+        via: VersionSetId,
+    ) -> (Self, Option<[Literal; 2]>) {
+        (
+            Clause::ConstrainsExcluded(candidate, aux, via),
+            Some([candidate.negative(), aux.positive()]),
+        )
+    }
+
+    /// Returns the building blocks needed for a new [WatchedLiterals] of the
+    /// [Clause::ConstrainsParent] kind. See [`Clause::constrains`] for the
+    /// meaning of the returned values.
+    fn constrains_parent(
+        parent: VariableId,
+        aux: VariableId,
+        via: VersionSetId,
+        decision_tracker: &DecisionTracker,
+    ) -> (Self, Option<[Literal; 2]>, bool) {
+        // It only makes sense to introduce a constrains clause when the parent
+        // solvable is undecided or going to be installed
+        assert_ne!(decision_tracker.assigned_value(parent), Some(false));
+
+        // If the auxiliary variable is already true, an excluded candidate is
+        // installed, which implies the parent solvable would be false (and we
+        // just asserted that it is not).
+        let conflict = decision_tracker.assigned_value(aux) == Some(true);
+
+        (
+            Clause::ConstrainsParent(parent, aux, via),
+            Some([parent.negative(), aux.negative()]),
+            conflict,
+        )
+    }
+
     /// Returns the ids of the solvables that will be watched as well as the
     /// clause itself.
     fn forbid_multiple(
@@ -309,6 +373,12 @@ impl<N: SolverId> Clause<N> {
                     .try_fold(init, visit)
             }
             Clause::Constrains(s1, s2, _) => [s1.negative(), s2.negative()]
+                .into_iter()
+                .try_fold(init, visit),
+            Clause::ConstrainsExcluded(candidate, aux, _) => [candidate.negative(), aux.positive()]
+                .into_iter()
+                .try_fold(init, visit),
+            Clause::ConstrainsParent(parent, aux, _) => [parent.negative(), aux.negative()]
                 .into_iter()
                 .try_fold(init, visit),
             Clause::ForbidMultipleInstances(s1, s2, _) => {
@@ -429,6 +499,38 @@ impl WatchedLiterals {
             requirement,
             decision_tracker,
         );
+
+        (
+            Self::from_kind_and_initial_watches(watched_literals),
+            conflict,
+            kind,
+        )
+    }
+
+    /// Shorthand method to construct a [Clause::ConstrainsExcluded] without
+    /// requiring complicated arguments.
+    pub fn constrains_excluded<N: SolverId>(
+        candidate: VariableId,
+        aux: VariableId,
+        requirement: VersionSetId,
+    ) -> (Option<Self>, Clause<N>) {
+        let (kind, watched_literals) = Clause::constrains_excluded(candidate, aux, requirement);
+        (Self::from_kind_and_initial_watches(watched_literals), kind)
+    }
+
+    /// Shorthand method to construct a [Clause::ConstrainsParent] without
+    /// requiring complicated arguments.
+    ///
+    /// The returned boolean value is true when adding the clause resulted in a
+    /// conflict.
+    pub fn constrains_parent<N: SolverId>(
+        parent: VariableId,
+        aux: VariableId,
+        requirement: VersionSetId,
+        decision_tracker: &DecisionTracker,
+    ) -> (Option<Self>, bool, Clause<N>) {
+        let (kind, watched_literals, conflict) =
+            Clause::constrains_parent(parent, aux, requirement, decision_tracker);
 
         (
             Self::from_kind_and_initial_watches(watched_literals),
@@ -649,6 +751,28 @@ impl<I: Interner> Display for ClauseDisplay<'_, I> {
                     v1,
                     v2.display(self.variable_map, self.interner),
                     v2,
+                    self.interner.display_version_set(version_set_id)
+                )
+            }
+            Clause::ConstrainsExcluded(candidate, aux, version_set_id) => {
+                write!(
+                    f,
+                    "ConstrainsExcluded({}({:?}), {}({:?}), {})",
+                    candidate.display(self.variable_map, self.interner),
+                    candidate,
+                    aux.display(self.variable_map, self.interner),
+                    aux,
+                    self.interner.display_version_set(version_set_id)
+                )
+            }
+            Clause::ConstrainsParent(parent, aux, version_set_id) => {
+                write!(
+                    f,
+                    "ConstrainsParent({}({:?}), {}({:?}), {})",
+                    parent.display(self.variable_map, self.interner),
+                    parent,
+                    aux.display(self.variable_map, self.interner),
+                    aux,
                     self.interner.display_version_set(version_set_id)
                 )
             }

--- a/src/solver/diagnostics.rs
+++ b/src/solver/diagnostics.rs
@@ -43,7 +43,9 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                 Clause::Learnt(..) => {
                     learned_clauses += 1;
                 }
-                Clause::Constrains(..) => {
+                Clause::Constrains(..)
+                | Clause::ConstrainsExcluded(..)
+                | Clause::ConstrainsParent(..) => {
                     constrains_clauses += 1;
                 }
                 Clause::AnyOf(..) => {
@@ -60,6 +62,8 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                 None => assertion_clauses += 1,
                 Some(_) => match clause {
                     Clause::Constrains(..)
+                    | Clause::ConstrainsExcluded(..)
+                    | Clause::ConstrainsParent(..)
                     | Clause::ForbidMultipleInstances(..)
                     | Clause::Lock(..)
                     | Clause::AnyOf(..) => binary_watched += 1,

--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -102,6 +102,12 @@ struct ConstraintCandidatesAvailable<'a, S> {
     candidates: &'a [S],
 }
 
+/// The minimum number of non-matching candidates a constraint must have before
+/// the shared auxiliary variable encoding is used (see
+/// [`Encoder::on_constraint_candidates_available`]). Below this, pairwise
+/// clauses need at most as many clauses and propagate in a single hop.
+const CONSTRAINS_AUX_ENCODING_THRESHOLD: usize = 4;
+
 impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
     pub fn new(
         state: &'a mut SolverState<D>,
@@ -436,21 +442,84 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
         );
 
         let variable = self.state.variable_map.intern_solvable_or_root(solvable_id);
-        for &forbidden_candidate in candidates {
-            let forbidden_candidate_var =
-                self.state.variable_map.intern_solvable(forbidden_candidate);
-            let (watched_literals, conflict, kind) = WatchedLiterals::constrains(
-                variable,
-                forbidden_candidate_var,
-                constraint,
-                &self.state.decision_tracker,
-            );
 
-            let clause_id = self.state.add_clause(watched_literals, kind);
+        if candidates.len() < CONSTRAINS_AUX_ENCODING_THRESHOLD {
+            // Pairwise encoding: one (¬parent ∨ ¬candidate) clause per
+            // excluded candidate.
+            for &forbidden_candidate in candidates {
+                let forbidden_candidate_var =
+                    self.state.variable_map.intern_solvable(forbidden_candidate);
+                let (watched_literals, conflict, kind) = WatchedLiterals::constrains(
+                    variable,
+                    forbidden_candidate_var,
+                    constraint,
+                    &self.state.decision_tracker,
+                );
 
-            if conflict {
-                self.conflicting_clauses.push(clause_id);
+                let clause_id = self.state.add_clause(watched_literals, kind);
+
+                if conflict {
+                    self.conflicting_clauses.push(clause_id);
+                }
             }
+            return;
+        }
+
+        // Shared encoding: the (¬candidate ∨ aux) clauses are emitted once per
+        // version set, each parent only adds a single (¬parent ∨ ¬aux) clause.
+        let aux_variable = match self.state.constrains_aux_vars.get(&constraint) {
+            Some(&aux_variable) => aux_variable,
+            None => {
+                let aux_variable = self
+                    .state
+                    .variable_map
+                    .alloc_constrains_violation_variable(constraint);
+                self.state
+                    .constrains_aux_vars
+                    .insert(constraint, aux_variable);
+
+                for &forbidden_candidate in candidates {
+                    let forbidden_candidate_var =
+                        self.state.variable_map.intern_solvable(forbidden_candidate);
+                    let (watched_literals, kind) = WatchedLiterals::constrains_excluded(
+                        forbidden_candidate_var,
+                        aux_variable,
+                        constraint,
+                    );
+                    let clause_id = self.state.add_clause(watched_literals, kind);
+
+                    // An already installed candidate must propagate
+                    // immediately so the parent clause below observes the
+                    // violation, just like the pairwise encoding does.
+                    if self
+                        .state
+                        .decision_tracker
+                        .assigned_value(forbidden_candidate_var)
+                        == Some(true)
+                    {
+                        self.state
+                            .decision_tracker
+                            .try_add_decision(
+                                Decision::new(aux_variable, true, clause_id),
+                                self.level,
+                            )
+                            .expect("a freshly allocated variable cannot be assigned false");
+                    }
+                }
+
+                aux_variable
+            }
+        };
+
+        let (watched_literals, conflict, kind) = WatchedLiterals::constrains_parent(
+            variable,
+            aux_variable,
+            constraint,
+            &self.state.decision_tracker,
+        );
+        let clause_id = self.state.add_clause(watched_literals, kind);
+        if conflict {
+            self.conflicting_clauses.push(clause_id);
         }
     }
 

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -225,6 +225,11 @@ pub(crate) struct SolverState<D: DependencyProvider> {
     /// solvable for a package.
     at_least_one_tracker: <D::NameId as SolverId>::Map<Option<VariableId>>,
 
+    /// The auxiliary variable of the shared constrains encoding per version
+    /// set. The [`Clause::ConstrainsExcluded`] clauses are emitted exactly
+    /// once, when the variable is allocated.
+    constrains_aux_vars: HashMap<VersionSetId, VariableId>,
+
     pub(crate) decision_tracker: DecisionTracker,
 
     /// Activity score per package.
@@ -251,6 +256,7 @@ impl<D: DependencyProvider> Default for SolverState<D> {
             clauses_added_for_solvable: Default::default(),
             at_most_one_trackers: Default::default(),
             at_least_one_tracker: Default::default(),
+            constrains_aux_vars: Default::default(),
             decision_tracker: Default::default(),
             name_activity: Default::default(),
             #[cfg(feature = "diagnostics")]
@@ -303,7 +309,9 @@ impl PropagationVisitsByType {
     fn count<N>(&mut self, clause: &Clause<N>) {
         match clause {
             Clause::Requires(..) => self.requires += 1,
-            Clause::Constrains(..) => self.constrains += 1,
+            Clause::Constrains(..)
+            | Clause::ConstrainsExcluded(..)
+            | Clause::ConstrainsParent(..) => self.constrains += 1,
             Clause::ForbidMultipleInstances(..) => self.forbid_multiple += 1,
             Clause::Lock(..) => self.lock += 1,
             Clause::Learnt(..) => self.learnt += 1,

--- a/src/solver/variable_map.rs
+++ b/src/solver/variable_map.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use crate::{
-    DenseIndex, Interner, VariableId,
+    DenseIndex, Interner, VariableId, VersionSetId,
     internal::solver_id::SolvableIdOrRoot,
     solver_id::{IdMap, SolverId},
 };
@@ -39,6 +39,10 @@ pub(crate) enum VariableOrigin<N, S> {
     /// A variable that indicates that any solvable of a particular package is
     /// part of the solution.
     AtLeastOne(N),
+
+    /// A variable that indicates that a candidate excluded by a constraint's
+    /// version set is installed.
+    ConstrainsViolation(VersionSetId),
 }
 
 impl<N: SolverId, S: SolverId> Default for VariableMap<N, S> {
@@ -110,6 +114,12 @@ impl<N: SolverId, S: SolverId> VariableMap<N, S> {
         self.alloc(VariableOrigin::AtLeastOne(name))
     }
 
+    /// Allocate a variable that indicates that a candidate that is excluded by
+    /// the given constraint's version set is installed.
+    pub fn alloc_constrains_violation_variable(&mut self, version_set: VersionSetId) -> VariableId {
+        self.alloc(VariableOrigin::ConstrainsViolation(version_set))
+    }
+
     /// Returns the origin of a variable. The origin describes the semantics of
     /// a variable.
     #[inline]
@@ -168,6 +178,15 @@ impl<I: Interner> Display for VariableDisplay<'_, I> {
             }
             VariableOrigin::AtLeastOne(name) => {
                 write!(f, "any-of({})", self.interner.display_name(name))
+            }
+            VariableOrigin::ConstrainsViolation(version_set) => {
+                write!(
+                    f,
+                    "constrains-violation({} {})",
+                    self.interner
+                        .display_name(self.interner.version_set_name(version_set)),
+                    self.interner.display_version_set(version_set)
+                )
             }
         }
     }

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -1344,6 +1344,126 @@ fn test_constrains_transitive() {
     "###);
 }
 
+/// The shared auxiliary-variable encoding emits the excluded candidates of a
+/// constraint only once: N parents sharing a constraint over a package with M
+/// excluded candidates produce M + N constrains clauses instead of N * M.
+#[test]
+fn test_constrains_shared_encoding_clause_count() {
+    let solve_and_count = |parents: usize| {
+        let mut provider = BundleBoxProvider::new();
+        // All 10 versions of pkg are excluded, enough for the shared encoding.
+        for v in 1..=10u32 {
+            provider.add_package("pkg", v.into(), &[], &[]);
+        }
+        let parent_names = (0..parents).map(|i| format!("p{i}")).collect::<Vec<_>>();
+        for name in &parent_names {
+            provider.add_package(name, 1.into(), &[], &["pkg 11..100"]);
+        }
+        let requirements =
+            provider.requirements(&parent_names.iter().map(String::as_str).collect::<Vec<_>>());
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        solver
+            .solve(problem)
+            .expect("nothing requires pkg, so the constraints are never violated");
+        solver.clause_count()
+    };
+
+    // Each additional parent adds one requires clause and one parent clause;
+    // the 10 excluded-candidate clauses are emitted only once.
+    let single_parent = solve_and_count(1);
+    let many_parents = solve_and_count(5);
+    assert_eq!(many_parents - single_parent, 4 * 2);
+}
+
+/// Constraints that exclude only a few candidates keep the direct pairwise
+/// encoding: every parent emits one clause per excluded candidate.
+#[test]
+fn test_constrains_pairwise_encoding_clause_count() {
+    let solve_and_count = |parents: usize| {
+        let mut provider = BundleBoxProvider::new();
+        // Only 2 versions of pkg are excluded, too few for the shared encoding.
+        provider.add_package("pkg", 1.into(), &[], &[]);
+        provider.add_package("pkg", 2.into(), &[], &[]);
+        let parent_names = (0..parents).map(|i| format!("p{i}")).collect::<Vec<_>>();
+        for name in &parent_names {
+            provider.add_package(name, 1.into(), &[], &["pkg 11..100"]);
+        }
+        let requirements =
+            provider.requirements(&parent_names.iter().map(String::as_str).collect::<Vec<_>>());
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        solver
+            .solve(problem)
+            .expect("nothing requires pkg, so the constraints are never violated");
+        solver.clause_count()
+    };
+
+    // Each additional parent adds one requires clause and one pairwise clause
+    // per excluded candidate.
+    let single_parent = solve_and_count(1);
+    let many_parents = solve_and_count(5);
+    assert_eq!(many_parents - single_parent, 4 * 3);
+}
+
+/// Like `test_unsat_constrains`, but with enough excluded candidates for the
+/// constraint to use the shared auxiliary-variable encoding. The rendered
+/// conflict must look exactly as if the constraint was encoded pairwise.
+#[test]
+fn test_unsat_constrains_shared_encoding() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("a", 10, vec!["b 50..100"]),
+        ("b", 55, vec![]),
+        ("b", 54, vec![]),
+        ("b", 53, vec![]),
+        ("b", 52, vec![]),
+        ("b", 51, vec![]),
+        ("b", 50, vec![]),
+        ("b", 42, vec![]),
+    ]);
+
+    provider.add_package("c", 10.into(), &[], &["b 0..50"]);
+    let error = solve_unsat(provider, &["a", "c"]);
+    insta::assert_snapshot!(error);
+}
+
+/// Reverse direction through the shared encoding: an installed candidate that
+/// is excluded by the constraint forbids the constraint's parent.
+#[test]
+fn test_unsat_constrains_shared_encoding_reverse() {
+    // x forces b=1, while a constrains b to [5,100) which excludes b=1..4.
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("x", 1, vec!["b 1..2"]),
+        ("b", 1, vec![]),
+        ("b", 2, vec![]),
+        ("b", 3, vec![]),
+        ("b", 4, vec![]),
+    ]);
+    provider.add_package("a", 1.into(), &[], &["b 5..100"]);
+    let error = solve_unsat(provider, &["x", "a"]);
+    insta::assert_snapshot!(error);
+}
+
+/// Multiple parents sharing the same constraint through the shared encoding.
+#[test]
+fn test_unsat_constrains_shared_encoding_multiple_parents() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("a", 10, vec!["b 50..100"]),
+        ("b", 55, vec![]),
+        ("b", 54, vec![]),
+        ("b", 53, vec![]),
+        ("b", 52, vec![]),
+        ("b", 51, vec![]),
+        ("b", 50, vec![]),
+        ("b", 42, vec![]),
+    ]);
+
+    provider.add_package("c", 10.into(), &[], &["b 0..50"]);
+    provider.add_package("d", 10.into(), &[], &["b 0..50"]);
+    let error = solve_unsat(provider, &["a", "c", "d"]);
+    insta::assert_snapshot!(error);
+}
+
 /// Multiple constraints from different parents on the same package.
 #[test]
 fn test_constrains_multiple_parents() {

--- a/tests/solver/snapshots/solver__unsat_constrains_shared_encoding.snap
+++ b/tests/solver/snapshots/solver__unsat_constrains_shared_encoding.snap
@@ -1,0 +1,13 @@
+---
+source: tests/solver/main.rs
+assertion_line: 1385
+expression: error
+---
+The following packages are incompatible
+├─ a * can be installed with any of the following options:
+│  └─ a 10 would require
+│     └─ b >=50, <100, which can be installed with any of the following options:
+│        └─ b 50 | 51 | 52 | 53 | 54 | 55
+└─ c * cannot be installed because there are no viable options:
+   └─ c 10 would constrain
+      └─ b >=0, <50, which conflicts with any installable versions previously reported

--- a/tests/solver/snapshots/solver__unsat_constrains_shared_encoding_multiple_parents.snap
+++ b/tests/solver/snapshots/solver__unsat_constrains_shared_encoding_multiple_parents.snap
@@ -1,0 +1,13 @@
+---
+source: tests/solver/main.rs
+assertion_line: 1423
+expression: error
+---
+The following packages are incompatible
+├─ a * can be installed with any of the following options:
+│  └─ a 10 would require
+│     └─ b >=50, <100, which can be installed with any of the following options:
+│        └─ b 50 | 51 | 52 | 53 | 54 | 55
+└─ c * cannot be installed because there are no viable options:
+   └─ c 10 would constrain
+      └─ b >=0, <50, which conflicts with any installable versions previously reported

--- a/tests/solver/snapshots/solver__unsat_constrains_shared_encoding_reverse.snap
+++ b/tests/solver/snapshots/solver__unsat_constrains_shared_encoding_reverse.snap
@@ -1,0 +1,13 @@
+---
+source: tests/solver/main.rs
+assertion_line: 1403
+expression: error
+---
+The following packages are incompatible
+├─ x * can be installed with any of the following options:
+│  └─ x 1 would require
+│     └─ b >=1, <2, which can be installed with any of the following options:
+│        └─ b 1
+└─ a * cannot be installed because there are no viable options:
+   └─ a 1 would constrain
+      └─ b >=5, <100, which conflicts with any installable versions previously reported


### PR DESCRIPTION
## Summary

This pull request replaces the pairwise `Constrains` clause encoding with a shared auxiliary-variable encoding. Previously every (parent, version set) constraint pair emitted one binary clause per candidate excluded by the version set, so the same excluded-candidate list was re-emitted for every parent sharing a constraint. On conda-forge style workloads these clauses dominate the clause database.

## Key Changes

Constraints whose version set excludes at least 4 candidates now share one auxiliary variable per version set, meaning "a candidate excluded by this version set is installed":

- **`ConstrainsExcluded`**: `(¬candidate ∨ aux)`, emitted once per version set;
- **`ConstrainsParent`**: `(¬parent ∨ ¬aux)`, one clause per (parent, version set) pair.

This reduces the constrains clause count from O(parents × candidates) to O(parents + candidates). Constraints excluding fewer than 4 candidates keep the pairwise encoding, which is smaller and propagates in a single hop for short lists.

## Performance Results

Benchmarked on the conda-forge dataset (linux-64 + noarch snapshot, 1000 randomized problems per seed, two seeds, identical problem sequences on both sides, clean release builds, 60s timeout):

| Speedup (2000 problems) | |
|--------|---------|
| mean | **1.27×** |
| median | 1.13× |
| p75 | 1.29× |
| p95 | 1.27× |
| p99 | **1.50×** |
| timeouts | 6 → 3 |

![Solve duration histogram](https://raw.githubusercontent.com/baszalmstra/resolvo/bench/constrains-encoding-graphs/duration-histogram.png)

![Per-problem duration difference](https://raw.githubusercontent.com/baszalmstra/resolvo/bench/constrains-encoding-graphs/duration-diff-histogram.png)

The gains extend the solvable frontier: main hits the 60s timeout on 6 problems, this PR on 3 (a strict subset), so 3 problems become solvable that previously were not. The largest single-problem improvement is 42.8s (a main timeout solved in 17.2s); the worst regression is +10.8s (40.9s vs 30.1s, both completing).

| Clauses & memory (cumulative, 2000 problems) | main | this PR | |
|--------|------|---------|---|
| total clauses | 5,359M | 975M | **5.5× fewer** |
| constrains clauses | 4,659M | 275M | **16.9× fewer** |
| clause memory | 171.5 GB | 31.2 GB | 5.5× less |
| per-solve solver memory, p50 | 85.6 MiB | 26.8 MiB | 3.2× less |
| per-solve solver memory, max | 510 MiB | 100 MiB | 5.1× less |
| variables | 53.0M | 54.3M | +2.6% |

Not a single problem of the 2000 uses more clauses or memory with the new encoding. Search effort drops as well: 1.39× fewer conflicts and 1.27× fewer clause visits in aggregate, and the smaller database also makes encoding 1.32× faster.

## Technical Rationale

Propagation strength is preserved, in two hops instead of one: `parent = true` propagates `aux = false` which propagates `¬candidate` for every excluded candidate, and conversely `candidate = true` propagates `aux = true` which propagates `¬parent`. Only one implication polarity is needed because the auxiliary variable is never decided directly; it only takes values through propagation. This is the one-sided (polarity-aware) variant of the [Tseytin transformation](https://en.wikipedia.org/wiki/Tseytin_transformation), due to [Plaisted and Greenbaum (1986)](https://doi.org/10.1016/S0747-7171(86)80028-1).

Conflict reporting reconstructs the original `parent → candidate` edges by pairing the two clause kinds through their shared auxiliary variable, so rendered conflict messages are identical to the pairwise encoding on the entire existing test suite.

## Correctness

- Every explicitly requested package resolves identically on all 2000 problems. 98.4% of solutions are byte-identical; the rest differ only in transitive picks, and both sides' picks are valid (CDCL learning takes a different path and transitive choices are greedy in decision order).
- 93% of unsat messages are byte-identical; the rest are valid alternative unsat cores produced by the unchanged renderer. Conflict-graph dumps confirmed that the edge reconstruction neither drops nor fabricates edges in the diverging cases.
- Known trade-off: on a ~0.5% tail of conflict-heavy problems, learning over the coarser auxiliary chain needs more conflicts and runs up to ~5× slower in ratio (worst observed +10.8s absolute); the aggregate distribution absorbs this comfortably, with p99 still 1.4-1.9× faster per seed.

New clause-count shape tests assert the M + N encoding (and N × M for the pairwise small case), and new unsat snapshot tests cover the shared encoding in forward, reverse, and multi-parent conflict directions; their snapshots are byte-identical to the pairwise encoding's output.
