### PR TITLE
perf: incremental assertion scans in propagate()

### DIFF
--- a/src/solver/assertion_scans.rs
+++ b/src/solver/assertion_scans.rs
@@ -1,0 +1,192 @@
+//! Assertions are clauses that consist of a single literal, e.g. `¬A1` for
+//! a candidate that may never be selected. Watches need two literals, so
+//! an assertion has no watches and propagation never wakes it on its own:
+//! its decision must already hold whenever propagation runs. The solver
+//! keeps two append-only lists of such clauses: `negative_assertions`
+//! (produced by the encoder) and the single-literal entries of
+//! `learnt_clause_ids` (produced by conflict analysis).
+//!
+//! Re-applying every entry of both lists at the start of every propagation
+//! round would keep that invariant, but almost every visit would be a
+//! no-op: the variable is usually already decided, propagation runs at
+//! least once per decision and once per conflict, and hard problems learn
+//! tens of thousands of clauses. So instead we only visit the entries for
+//! which something could have changed. Between two propagation rounds that
+//! is exactly:
+//!
+//! 1. the entries appended since the last scan, and
+//! 2. the entries whose satisfying assignment was popped by backtracking.
+//!
+//! The first set is cheap to find: the lists are append-only, so a cursor
+//! per list marks how far we have scanned, and everything beyond it is
+//! new. While scanning new learnt entries we also drop every multi-literal
+//! clause once and for all (watches handle those, and a learnt clause
+//! never changes after allocation); only the single-literal entries, which
+//! are rare, are kept for re-inspection in `learnt_single`.
+//!
+//! For the second set we look at the trail: the chronological assignment
+//! log (the `DecisionTracker` stack). Assignments are pushed onto it and
+//! backtracking pops a suffix, so a truncation to length `n` pops exactly
+//! the assignments at positions `>= n`. Rather than remembering a position
+//! per entry we keep a single bound per list, `verified_up_to`: every
+//! scanned entry holds its asserted value through an assignment at or
+//! below that position. The decision tracker remembers the lowest trail
+//! length reached since our previous scan, the floor
+//! (`DecisionTracker::take_assert_floor`):
+//!
+//! ```text
+//! backing list  [ a b c d e | f g ]
+//!                           ^ cursor: f and g are new
+//!
+//! trail         [ .  .  .  .  .  .  .  . ]   (one assignment per slot)
+//!                       ^           ^
+//!                       floor       verified_up_to
+//! ```
+//!
+//! If the floor stayed above `verified_up_to`, no truncation can have
+//! popped a verifying assignment and the entire list is skipped. Otherwise
+//! (the situation drawn above) some assignment may be gone, and the list
+//! is marked dirty: the next scan re-applies every scanned single-literal
+//! entry, in index order, before processing the new tail. Every visit runs
+//! the ordinary per-entry code and then records the current trail top as
+//! the new bound — the trail only grows within a round, so the position of
+//! the last visit bounds all of them. A conflict aborts the scan with the
+//! dirty flag still set, so the remaining entries are re-checked in the
+//! next round.
+//!
+//! Note that none of this changes anything observable. A skipped entry
+//! still holds its asserted value, so visiting it would just return
+//! `Ok(false)` from `try_add_decision`: no decision, no level change, no
+//! trace output, no conflict. And because dirty entries are re-applied in
+//! index order before the tail, visits happen in the same order as a full
+//! scan, so decisions, levels, traces, and which conflict surfaces first
+//! are all unchanged.
+
+/// Incremental scan state for one assertion list.
+#[derive(Default)]
+pub(crate) struct ScanState {
+    /// Entries `< cursor` of the backing list have been inspected.
+    cursor: usize,
+    /// Upper bound on the trail positions of the assignments satisfying
+    /// the inspected entries.
+    verified_up_to: usize,
+    /// A verified assignment may have been popped: re-verify every
+    /// inspected entry. Sticky until a rescan completes without a
+    /// conflict.
+    dirty: bool,
+}
+
+impl ScanState {
+    /// Mark the list dirty when a truncation since the previous call
+    /// reached `verified_up_to`. `floor` is the lowest trail length
+    /// observed in between ([`DecisionTracker::take_assert_floor`]).
+    ///
+    /// [`DecisionTracker::take_assert_floor`]:
+    /// crate::solver::decision_tracker::DecisionTracker::take_assert_floor
+    #[inline]
+    pub(crate) fn sync(&mut self, floor: usize) {
+        if self.verified_up_to >= floor {
+            self.dirty = true;
+        }
+    }
+
+    /// Whether the inspected entries must be re-verified.
+    #[inline]
+    pub(crate) fn needs_rescan(&self) -> bool {
+        self.dirty
+    }
+
+    /// Record a completed, conflict-free rescan.
+    #[inline]
+    pub(crate) fn mark_clean(&mut self) {
+        self.dirty = false;
+    }
+
+    /// The number of entries inspected so far.
+    #[inline]
+    pub(crate) fn cursor(&self) -> usize {
+        self.cursor
+    }
+
+    /// Advance past the entry at the cursor.
+    #[inline]
+    pub(crate) fn advance(&mut self) {
+        self.cursor += 1;
+    }
+
+    /// Record an entry verified through the assignment at (or below)
+    /// trail position `position`. Positions are non-decreasing within a
+    /// scan, so the last one bounds every inspected entry.
+    #[inline]
+    pub(crate) fn record(&mut self, position: usize) {
+        self.verified_up_to = position;
+    }
+}
+
+/// The scan state of both assertion lists, in scan order.
+#[derive(Default)]
+pub(crate) struct AssertionScans {
+    /// `Solver::decide_assertions` (`SolverState::negative_assertions`).
+    /// Every entry is single-literal; rescans walk `0..cursor` directly.
+    pub(crate) negative: ScanState,
+    /// `Solver::decide_learned` (`SolverState::learnt_clause_ids`).
+    pub(crate) learnt: ScanState,
+    /// Indices (ascending) of the single-literal entries of
+    /// `learnt_clause_ids`: the only learnt entries a rescan visits.
+    pub(crate) learnt_single: Vec<u32>,
+}
+
+impl AssertionScans {
+    /// Sync both lists with the backtracking since the previous round.
+    pub(crate) fn sync(&mut self, floor: usize) {
+        self.negative.sync(floor);
+        self.learnt.sync(floor);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dirty_only_when_the_floor_reaches_the_verified_bound() {
+        let mut list = ScanState::default();
+
+        // A fresh list is conservatively dirty against the initial floor
+        // of zero; the (empty) rescan completes immediately.
+        list.sync(0);
+        assert!(list.needs_rescan());
+        list.mark_clean();
+
+        // Verify three entries at positions 4, 9, 25.
+        for position in [4, 9, 25] {
+            list.record(position);
+            list.advance();
+        }
+        assert_eq!(list.cursor(), 3);
+
+        // No truncation: nothing to re-verify.
+        list.sync(usize::MAX);
+        assert!(!list.needs_rescan());
+
+        // A truncation that stayed above the verified bound proves all
+        // verified assignments survived.
+        list.sync(26);
+        assert!(!list.needs_rescan());
+
+        // A truncation at or below the verified bound forces a rescan, and the
+        // flag is sticky until a rescan completes.
+        list.sync(25);
+        assert!(list.needs_rescan());
+        list.sync(usize::MAX);
+        assert!(list.needs_rescan());
+
+        // A completed rescan at a lower trail top tightens the bound.
+        list.record(7);
+        list.mark_clean();
+        list.sync(8);
+        assert!(!list.needs_rescan());
+        list.sync(7);
+        assert!(list.needs_rescan());
+    }
+}

--- a/src/solver/decision_tracker.rs
+++ b/src/solver/decision_tracker.rs
@@ -1,13 +1,20 @@
 use crate::solver::{decision::Decision, decision_map::DecisionMap};
 use crate::{VariableId, internal::id::ClauseId};
 
-/// Tracks the assignments to solvables, keeping a log that can be used to backtrack, and a map that
+/// Tracks the assignments to solvables, keeping a log that can be used to backtrack (the *trail*:
+/// assignments are pushed in chronological order and backtracking pops a suffix), and a map that
 /// can be used to query the current value assigned
 #[derive(Default)]
 pub(crate) struct DecisionTracker {
     map: DecisionMap,
     stack: Vec<Decision>,
     propagate_index: usize,
+
+    /// The lowest stack length observed since the last call to
+    /// [`Self::take_assert_floor`]. The assertion scans
+    /// (`crate::solver::assertion_scans`) use it to detect assignments
+    /// popped by backtracking.
+    assert_floor: usize,
 }
 
 impl DecisionTracker {
@@ -78,6 +85,15 @@ impl DecisionTracker {
 
             self.undo_last();
         }
+
+        // Record the trough for the assertion scans. A backtrack only pops
+        // (never pushes), so the minimum stack length over the whole
+        // sequence is its final length; updating the floor once here is
+        // equivalent to updating it on every pop. Conflict analysis pops
+        // directly via `undo_last` but always finishes with an
+        // `undo_until` to the backjump level, which reaches the deepest
+        // point, so that path is covered here too.
+        self.assert_floor = self.assert_floor.min(self.stack.len());
     }
 
     pub(crate) fn undo_last(&mut self) -> (Decision, u32) {
@@ -98,5 +114,68 @@ impl DecisionTracker {
         let &decision = self.stack[self.propagate_index..].iter().next()?;
         self.propagate_index += 1;
         Some(decision)
+    }
+
+    /// The number of decisions on the stack.
+    #[inline]
+    pub(crate) fn stack_len(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Returns the lowest stack length observed since the previous call
+    /// and re-arms the marker to `usize::MAX`.
+    ///
+    /// A truncation to length `n` pops exactly the positions `>= n`, so
+    /// an assignment survived every truncation since the previous call
+    /// if and only if its position is below the returned floor. When
+    /// nothing was undone the floor is `usize::MAX`; a fresh or cleared
+    /// tracker reports zero (everything was popped).
+    #[inline]
+    pub(crate) fn take_assert_floor(&mut self) -> usize {
+        std::mem::replace(&mut self.assert_floor, usize::MAX)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DenseIndex;
+
+    fn decision(index: usize, value: bool) -> Decision {
+        Decision::new(
+            VariableId::from_index(index),
+            value,
+            ClauseId::install_root(),
+        )
+    }
+
+    #[test]
+    fn assert_floor_reports_the_deepest_truncation_or_max_when_untouched() {
+        let mut tracker = DecisionTracker::default();
+        // A fresh tracker invalidates everything.
+        assert_eq!(tracker.take_assert_floor(), 0);
+        // Taking the floor re-arms it: nothing was undone since.
+        assert_eq!(tracker.take_assert_floor(), usize::MAX);
+
+        for i in 1..=4 {
+            tracker
+                .try_add_decision(decision(i, true), i as u32)
+                .unwrap();
+        }
+        // Additions alone never lower the floor.
+        assert_eq!(tracker.take_assert_floor(), usize::MAX);
+
+        // Undo to level 2 (stack length 2), then regrow: the floor reports
+        // the truncation point, not the final length.
+        tracker.undo_until(2);
+        for i in 5..=7 {
+            tracker.try_add_decision(decision(i, false), 3).unwrap();
+        }
+        assert_eq!(tracker.take_assert_floor(), 2);
+        assert_eq!(tracker.take_assert_floor(), usize::MAX);
+
+        // A full clear resets the floor to zero: everything is invalidated.
+        tracker.clear();
+        assert_eq!(tracker.take_assert_floor(), 0);
     }
 }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,6 +1,7 @@
 use std::{any::Any, fmt::Display, ops::ControlFlow};
 
 use ahash::{HashMap, HashSet};
+use assertion_scans::AssertionScans;
 pub use cache::SolverCache;
 use clause::{Clause, Literal, WatchedLiterals};
 use conditions::{Disjunction, DisjunctionId};
@@ -29,6 +30,7 @@ use crate::{
     utils::{IndexedSet, Mapping},
 };
 
+mod assertion_scans;
 mod binary_encoding;
 mod cache;
 pub(crate) mod clause;
@@ -235,6 +237,10 @@ pub(crate) struct SolverState<D: DependencyProvider> {
     /// Activity score per package.
     name_activity: <D::NameId as SolverId>::Map<f32>,
 
+    /// Incremental scan state for [`Self::negative_assertions`] and
+    /// [`Self::learnt_clause_ids`]; see [`assertion_scans`].
+    assertion_scans: AssertionScans,
+
     #[cfg(feature = "diagnostics")]
     propagation_counters: PropagationCounters,
 }
@@ -259,6 +265,7 @@ impl<D: DependencyProvider> Default for SolverState<D> {
             constrains_aux_vars: Default::default(),
             decision_tracker: Default::default(),
             name_activity: Default::default(),
+            assertion_scans: Default::default(),
             #[cfg(feature = "diagnostics")]
             propagation_counters: Default::default(),
         }
@@ -1233,6 +1240,12 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
             return Err(PropagationError::Cancelled(value));
         };
 
+        // Re-arm the assertion scans: assertions whose verifying
+        // assignment was popped since the previous round must be
+        // re-applied below.
+        let assert_floor = self.state.decision_tracker.take_assert_floor();
+        self.state.assertion_scans.sync(assert_floor);
+
         // Add decisions from assertions and learned clauses. If any of these cause a
         // conflict, we will return an error.
         self.decide_assertions(level)?;
@@ -1385,67 +1398,129 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     /// Add decisions for negative assertions derived from other rules
     /// (assertions are clauses that consist of a single literal, and
     /// therefore do not have watches).
+    ///
+    /// Incremental: re-verifies the inspected entries only when
+    /// backtracking may have popped one of their assignments, then
+    /// applies the appended tail. See [`assertion_scans`].
     fn decide_assertions(&mut self, level: u32) -> Result<(), PropagationError> {
-        for &(solvable_id, clause_id) in &self.state.negative_assertions {
-            let value = false;
-            let decided = self
-                .state
-                .decision_tracker
-                .try_add_decision(Decision::new(solvable_id, value, clause_id), level)
-                .map_err(|_| PropagationError::Conflict(solvable_id, value, clause_id))?;
-
-            if decided {
-                tracing::trace!(
-                    "Negative assertions derived from other rules: Propagate assertion {} = {}",
-                    solvable_id.display(&self.state.variable_map, self.provider()),
-                    value
-                );
+        if self.state.assertion_scans.negative.needs_rescan() {
+            // A conflict (`?`) leaves the flag set, so the remaining
+            // entries are re-checked next round.
+            for index in 0..self.state.assertion_scans.negative.cursor() {
+                let position = self.apply_negative_assertion(index, level)?;
+                self.state.assertion_scans.negative.record(position);
             }
+            self.state.assertion_scans.negative.mark_clean();
+        }
+        while self.state.assertion_scans.negative.cursor() < self.state.negative_assertions.len() {
+            let index = self.state.assertion_scans.negative.cursor();
+            let position = self.apply_negative_assertion(index, level)?;
+            self.state.assertion_scans.negative.record(position);
+            self.state.assertion_scans.negative.advance();
         }
         Ok(())
     }
 
-    /// Add decisions derived from learnt clauses.
+    /// Apply the negative assertion at `index`. Returns the trail
+    /// position at (or above) the assignment satisfying it.
+    fn apply_negative_assertion(
+        &mut self,
+        index: usize,
+        level: u32,
+    ) -> Result<usize, PropagationError> {
+        let (solvable_id, clause_id) = self.state.negative_assertions[index];
+        let value = false;
+        let decided = self
+            .state
+            .decision_tracker
+            .try_add_decision(Decision::new(solvable_id, value, clause_id), level)
+            .map_err(|_| PropagationError::Conflict(solvable_id, value, clause_id))?;
+
+        if decided {
+            tracing::trace!(
+                "Negative assertions derived from other rules: Propagate assertion {} = {}",
+                solvable_id.display(&self.state.variable_map, self.provider()),
+                value
+            );
+        }
+        // The variable is assigned (a fresh decision sits on top of the
+        // stack; an existing assignment sits at or below the top), so the
+        // stack is non-empty and `len - 1` bounds the assignment position.
+        Ok(self.state.decision_tracker.stack_len() - 1)
+    }
+
+    /// Add decisions derived from single-literal learnt clauses,
+    /// incrementally like [`Self::decide_assertions`]. Rescans walk only
+    /// the single-literal entries; multi-literal learnt clauses are
+    /// inspected once at ingest and never again (their literal lists are
+    /// immutable and watches handle them).
     fn decide_learned(&mut self, level: u32) -> Result<(), PropagationError> {
-        // Assertions derived from learnt rules
-        for learn_clause_idx in 0..self.state.learnt_clause_ids.len() {
-            let clause_id = self.state.learnt_clause_ids[learn_clause_idx];
-            let clause = self.state.clauses.kinds[clause_id.to_index()];
-            let Clause::Learnt(learnt_index) = clause else {
-                unreachable!();
-            };
-
-            let literals = &self.state.learnt_clauses[learnt_index];
-            if literals.len() > 1 {
-                continue;
+        if self.state.assertion_scans.learnt.needs_rescan() {
+            for k in 0..self.state.assertion_scans.learnt_single.len() {
+                let index = self.state.assertion_scans.learnt_single[k] as usize;
+                let position = self
+                    .apply_learnt_assertion(index, level)?
+                    .expect("only single-literal learnt clauses are tracked");
+                self.state.assertion_scans.learnt.record(position);
             }
-
-            debug_assert!(!literals.is_empty());
-
-            let literal = literals[0];
-            let decision = literal.satisfying_value();
-
-            let decided = self
-                .state
-                .decision_tracker
-                .try_add_decision(
-                    Decision::new(literal.variable(), decision, clause_id),
-                    level,
-                )
-                .map_err(|_| PropagationError::Conflict(literal.variable(), decision, clause_id))?;
-
-            if decided {
-                tracing::trace!(
-                    "├─ Propagate assertion {} = {}",
-                    literal
-                        .variable()
-                        .display(&self.state.variable_map, self.provider()),
-                    decision
-                );
+            self.state.assertion_scans.learnt.mark_clean();
+        }
+        while self.state.assertion_scans.learnt.cursor() < self.state.learnt_clause_ids.len() {
+            let index = self.state.assertion_scans.learnt.cursor();
+            if let Some(position) = self.apply_learnt_assertion(index, level)? {
+                self.state.assertion_scans.learnt.record(position);
+                self.state.assertion_scans.learnt_single.push(index as u32);
             }
+            self.state.assertion_scans.learnt.advance();
         }
 
         Ok(())
+    }
+
+    /// Apply the single-literal learnt clause at `index` of
+    /// `learnt_clause_ids`. Returns the trail position at (or above) the
+    /// satisfying assignment, or `None` for a multi-literal clause.
+    fn apply_learnt_assertion(
+        &mut self,
+        index: usize,
+        level: u32,
+    ) -> Result<Option<usize>, PropagationError> {
+        let clause_id = self.state.learnt_clause_ids[index];
+        let clause = self.state.clauses.kinds[clause_id.to_index()];
+        let Clause::Learnt(learnt_index) = clause else {
+            unreachable!();
+        };
+
+        let literals = &self.state.learnt_clauses[learnt_index];
+        if literals.len() > 1 {
+            return Ok(None);
+        }
+
+        debug_assert!(!literals.is_empty());
+
+        let literal = literals[0];
+        let decision = literal.satisfying_value();
+
+        let decided = self
+            .state
+            .decision_tracker
+            .try_add_decision(
+                Decision::new(literal.variable(), decision, clause_id),
+                level,
+            )
+            .map_err(|_| PropagationError::Conflict(literal.variable(), decision, clause_id))?;
+
+        if decided {
+            tracing::trace!(
+                "├─ Propagate assertion {} = {}",
+                literal
+                    .variable()
+                    .display(&self.state.variable_map, self.provider()),
+                decision
+            );
+        }
+
+        Ok(Some(self.state.decision_tracker.stack_len() - 1))
     }
 
     /// Adds the clause with `clause_id` to the current [`Conflict`]

--- a/tools/solve-snapshot/src/main.rs
+++ b/tools/solve-snapshot/src/main.rs
@@ -37,6 +37,11 @@ struct Opts {
     #[clap(long, default_value = "0")]
     seed: u64,
 
+    /// Skip the first N problems (still generated, so the RNG advances
+    /// deterministically and `--skip K -n K+1` replays exactly problem K).
+    #[clap(long, default_value = "0")]
+    skip: usize,
+
     /// Enable tracing output (set RUST_LOG for verbosity, e.g. RUST_LOG=info)
     #[clap(long)]
     tracing: bool,
@@ -142,16 +147,32 @@ fn main() {
             })
             .to_string();
 
+        if i < opts.skip {
+            continue;
+        }
+
         let start = Instant::now();
 
         let problem = Problem::default().requirements(requirements);
         let mut solver = Solver::new(provider);
         let mut records = None;
         let mut error = None;
-        let result = solver.solve(problem);
+        let result =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| solver.solve(problem)));
         let duration = start.elapsed();
         match result {
-            Ok(solution) => {
+            Err(_) => {
+                eprintln!(
+                    "{}",
+                    style(format!(
+                        "==> PANIC after {:.2}ms",
+                        duration.as_secs_f64() * 1000.0
+                    ))
+                    .red()
+                );
+                error = Some("panic".to_string());
+            }
+            Ok(Ok(solution)) => {
                 eprintln!(
                     "{}",
                     style(format!(
@@ -163,7 +184,7 @@ fn main() {
                 );
                 records = Some(solution.len())
             }
-            Err(UnsolvableOrCancelled::Unsolvable(problem)) => {
+            Ok(Err(UnsolvableOrCancelled::Unsolvable(problem))) => {
                 eprintln!(
                     "{}",
                     style(format!(
@@ -174,7 +195,7 @@ fn main() {
                 );
                 error = Some(problem.display_user_friendly(&solver).to_string());
             }
-            Err(_) => {
+            Ok(Err(_)) => {
                 eprintln!(
                     "{}",
                     style(format!(


### PR DESCRIPTION
This PR makes the assertion scans at the top of `Solver::propagate` incremental. Instead of re-applying every negative assertion and every single-literal learnt clause on every call, the solver now visits only the entries that were appended since the previous propagation round or whose verifying assignment was popped by backtracking.

The solver behavior is preserved **exactly**: on 2×1000 random conda-forge problems, statuses, solutions, record counts, and unsat messages are identical to main, except three problems at the 60 s timeout boundary that main cannot finish and this PR can. Only the time changes.

## Background

Assertions are single-literal clauses: they have no watches, so their decision must hold whenever propagation runs. On main, `propagate()` starts every call with two full rescans: every entry of `negative_assertions` and every entry of `learnt_clause_ids`, each visit a `try_add_decision` that no-ops once the variable is decided — and each multi-literal learnt clause is loaded just to be inspected and skipped. Propagate runs at least once per decision and once per conflict, and conflict-heavy problems learn tens of thousands of clauses, so the learnt rescan alone is O(learnt clauses × propagate calls), almost all of it multi-literal clauses that can never act (watches handle them) and assertions that already hold.

Mainline SAT solvers ([MiniSat](https://github.com/niklasso/minisat), [CaDiCaL](https://github.com/arminbiere/cadical)) never rescan: a unit clause is enqueued once at the root level, where no backjump can pop it. resolvo cannot assert at the root — the lists grow mid-search as the encoder runs, and assertions are recorded at the current level, so a backjump can pop them and they must be re-applied. But between two propagate calls only two things can make an entry actionable again: it was appended since the last scan (both lists are append-only), or the assignment that satisfied it was popped by backtracking. This PR tracks exactly those two sets, the same observation that motivates [two watched literals](https://www.princeton.edu/~chaff/publication/DAC2001v56.pdf) — never revisit what provably cannot have changed — applied to the assertion lists.

## Implementation

Per assertion list, three small pieces of state (`src/solver/assertion_scans.rs`):

* A **cursor**: entries at or beyond it have never been inspected; the lists are append-only, so a single index is exact. Multi-literal learnt clauses are inspected once at ingest and never again (their literal lists are immutable after allocation and watches handle them); the indices of the single-literal entries go into a side list, so rescans never touch the multi-literal majority. Single-literal learnt clauses are rare, so this filtering alone removes almost all of the learnt-scan waste.
* A **verified position bound**: `verified_up_to` is an upper bound on the trail positions of the assignments satisfying the inspected entries — within a scan the trail only grows, so the position recorded by the last visit bounds them all. The `DecisionTracker` gains an *assert floor*, the lowest trail length reached since the previous propagation round (one `usize::min` per undo, the same min-since-last-observation idea as a sync floor; propagation pays nothing). A truncation to length `n` pops exactly the positions `>= n`, so `floor > verified_up_to` proves every verified assignment survived and the whole scan is skipped with one integer comparison.
* A **dirty flag**, set when the floor reaches the bound: the next scan re-verifies every inspected single-literal entry once, in index order, with the unchanged per-entry code. The flag is sticky until a rescan completes without a conflict, so a conflict mid-rescan leaves the remaining entries pending, exactly like the historical early return.

The steady-state cost on conflict-light problems is one integer comparison per list per propagate call; a new entry costs the original per-entry code plus one store.

A first iteration tracked individual entries instead — one `(position, group, index)` record per verified assertion in a max-heap, invalidated through the same floor into per-list pending sets — so a rescan visited only the entries actually popped. That precision measured uniformly *slower* on conflict-light problems (a consistent 7-9% on the sub-second class, where the removed rescans were too short to amortize a heap push per assertion), so it was dropped: with the single-literal side list the rescan sets are tiny, and re-verifying all of them on the rare backjump below the bound costs about as much as one historical scan of that list.

## Why the result is exactly the same

The scan is skipped only while every inspected entry provably still holds its asserted value (any truncation that could have popped a verifying assignment lowers the floor to at or below the bound and marks the list dirty first, and no truncation can happen mid-propagate), so a skipped scan consists solely of visits on which `try_add_decision` would have returned `Ok(false)`: no decision, no level change, no trace output, no possible conflict. A rescan visits a superset of the entries the historical scan would have acted on, in the historical ascending-index order with the byte-for-byte original per-entry code, so the first visit that does change state — a new decision, or the conflict `Err` — is the same one the full rescan would have hit. Re-applied assertions record the current propagate level, exactly as the historical rescan did after a backjump, and `SolverState::default()` resets scan state, tracker, and lists together between solves.

## Performance Results

Benchmarked on a conda-forge snapshot (linux-64 + noarch, `tools/solve-snapshot`), seeds 0 and 1, 1000 problems each, 60 s timeout, identical problem sequences on both sides, strictly sequential runs, measured against current main (`61a0629`); the branch is rebased on it. Three problems (one in seed 0, two in seed 1) hit a pre-existing index-out-of-bounds panic in the benchmark harness's `SnapshotProvider::version_set_name` (`src/snapshot.rs:445`, version sets added by `add_package_requirement`) on *both* sides identically; the harness now catches the panic and records the row instead of aborting the run, and those three rows are excluded from the comparison. The solver is not involved; a fix is left to a separate PR.

| metric | main | this PR |
|---|---:|---:|
| total solve time (seed 0) | 2069.7 s | **1928.7 s (−6.8%)** |
| total solve time (seed 1) | 2252.5 s | **2145.7 s (−4.7%)** |
| p99 (seed 0 / 1) | 26.79 s / 51.42 s | **23.67 s (−12%) / 42.45 s (−17%)** |
| p50 (seed 0 / 1) | 0.673 s / 0.858 s | 0.671 s (−0.3%) / 0.872 s (+1.6%) |
| ok / unsat / timeout (seed 0) | 782 / 212 / 5 | 783 / 213 / **3** |
| ok / unsat / timeout (seed 1) | 748 / 241 / 9 | 748 / 242 / **8** |

The skip check costs nothing measurable on the easy bulk of the corpus (p25/p50 ratios are 1.00x-1.02x), and the win concentrates where the rescans dominated: conflict-heavy solves with large learnt databases. The three status changes are all in this PR's favor and main's timeouts are a strict superset: seed 0 problem 115 proves unsat in 59.99 s, problem 996 solves (472 records) in 58.2 s, and seed 1 problem 723 proves unsat in 53.4 s, where main is cancelled at 60 s on all three.

<img src="https://raw.githubusercontent.com/baszalmstra/resolvo/assets/assertion-scans-graphs/duration-histogram.png" />
<img src="https://raw.githubusercontent.com/baszalmstra/resolvo/assets/assertion-scans-graphs/duration-diff-histogram.png" />

Top 5 most-improved problems (this PR vs main):

- `nmaipy, dbstep, ipypivot, pandas-profiling, icechunk, ...` | **10.06s faster**
- `partial-json-parser, presto-fit, esssans, flask-themes2, ...` | **9.62s faster**
- `htmlgen, kfp-tekton-server-api, algopy, rb-jemoji, napari-...` | **9.01s faster**
- `trame, tetraframework, impact-t, hdf5-external-filter-plug...` | **8.97s faster**
- `autogluon.text, rtopy, pypinyin, r-bayestestr` | **8.52s faster**

The worst regression over all 1997 problems is +5.3 s on a 19.5 s unsat solve (seed 0 problem 181, both sides completing); the same problem measured +1.1 s in an earlier interleaved A-B-A pairing, so a good part of that is machine drift. The next-worst regression is +1.6 s.

## Correctness

- Statuses are identical on all 1997 mutually-completed problems except the three timeout-boundary flips above. Every mutually-solved problem (1530) returns the same number of records, and every mutual unsat message (453) is byte-identical.
- The full test suite passes with and without `--features diagnostics`, with zero snapshot churn: the per-entry application code is untouched, so decisions, levels, traces, and which conflict surfaces first are unchanged by construction.
- Unit tests pin the bookkeeping invariants: the assert floor (truncation tracking, re-arming, reset-to-zero on `clear()`) and the scan state (skip above the bound, dirty at or below it, stickiness until a completed rescan, bound tightening after a rescan at a shallower trail).
- The permanent skip of multi-literal learnt clauses relies on learnt literal lists being immutable after allocation, which holds today (they are only created in `analyze`); in-place clause shrinking would need to re-ingest the shrunk clause.

https://claude.ai/code/session_01SHWyg5brqJFEiNEY7ZbgBq

---
_Generated by [Claude Code](https://claude.ai/code/session_01SHWyg5brqJFEiNEY7ZbgBq)_