### PR TITLE
perf: classic CDCL restarts (Luby) with a futility gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The solver now uses a classic CDCL restart policy (Luby sequence over a
+  base interval of 128 conflicts, tuned on the conda-forge corpus), which
+  dramatically reduces solve times on conflict-heavy and unsolvable
+  problems. As with any solver heuristic improvement, valid solutions may
+  differ between resolvo versions: a small tail of problems now resolves to
+  a different but equally valid solution. Version preference is unaffected.
+
 ## [0.10.4](https://github.com/prefix-dev/resolvo/compare/resolvo-v0.10.3...resolvo-v0.10.4) - 2026-06-02
 
 ### Other

--- a/src/requirement.rs
+++ b/src/requirement.rs
@@ -117,6 +117,24 @@ impl<V> RequirementMap<V> {
             Requirement::Union(id) => self.unions.insert(id, value),
         }
     }
+
+    #[inline]
+    pub fn get_mut(&mut self, key: Requirement) -> Option<&mut V> {
+        match key {
+            Requirement::Single(id) => self.singles.get_mut(id),
+            Requirement::Union(id) => self.unions.get_mut(id),
+        }
+    }
+
+    /// Returns a mutable reference to the value for `key`, inserting the
+    /// result of `default` first if the key has no entry yet.
+    #[inline]
+    pub fn get_or_insert_with(&mut self, key: Requirement, default: impl FnOnce() -> V) -> &mut V {
+        match key {
+            Requirement::Single(id) => self.singles.get_or_insert_with(id, default),
+            Requirement::Union(id) => self.unions.get_or_insert_with(id, default),
+        }
+    }
 }
 
 impl<V> std::ops::Index<Requirement> for RequirementMap<V> {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -398,7 +398,11 @@ impl<'s> SnapshotProvider<'s> {
     /// Adds another requirement that matches any version of a package.
     /// If you use "*" as the matcher, it will match any version of the package.
     pub fn add_package_requirement(&mut self, name: NameId, matcher: &str) -> VersionSetId {
-        let id = self.snapshot.version_sets.max() + self.additional_version_sets.len();
+        // Additional version sets are allocated directly after the highest
+        // index present in the snapshot. `Mapping::max()` returns the highest
+        // inserted *index* (not a count), so the first free index is one past
+        // it.
+        let id = self.snapshot.version_sets.max() + 1 + self.additional_version_sets.len();
         let package = self.package(name);
 
         let matching_candidates = package
@@ -441,8 +445,12 @@ impl<'s> SnapshotProvider<'s> {
     fn version_set(&self, version_set: VersionSetId) -> &VersionSet {
         let idx = version_set.to_index();
         let max_idx = self.snapshot.version_sets.max();
-        if idx >= max_idx {
-            &self.additional_version_sets[idx - max_idx]
+        // Indices up to and including `max_idx` belong to the snapshot;
+        // anything beyond was allocated by `add_package_requirement`. Using
+        // `>=` here would shadow the snapshot's highest-index version set
+        // with the first additional one (and panic when none was added).
+        if idx > max_idx {
+            &self.additional_version_sets[idx - max_idx - 1]
         } else {
             self.snapshot
                 .version_sets

--- a/src/solver/clause.rs
+++ b/src/solver/clause.rs
@@ -170,9 +170,12 @@ impl<N: SolverId> Clause<N> {
         condition: Option<(DisjunctionId, &[Literal])>,
         decision_tracker: &DecisionTracker,
     ) -> (Self, Option<[Literal; 2]>, bool) {
-        // It only makes sense to introduce a requires clause when the parent solvable
-        // is undecided or going to be installed
-        assert_ne!(decision_tracker.assigned_value(parent), Some(false));
+        // On the lazy-conditional path the parent may already have been
+        // propagated false by the time this clause is built (e.g. a deferred
+        // requirement whose condition fires after the parent was forbidden).
+        // The clause is currently satisfied by `¬parent`, but that assignment
+        // can be backtracked later, so the clause must still be added.
+        let parent_is_false = decision_tracker.assigned_value(parent) == Some(false);
 
         let kind = Clause::Requires(parent, condition.map(|d| d.0), requirement);
 
@@ -190,9 +193,8 @@ impl<N: SolverId> Clause<N> {
         let mut literals = condition_literals.chain(candidate_literals).peekable();
         let Some(&first_literal) = literals.peek() else {
             // If there are no candidates and there is no condition, then this clause is an
-            // assertion.
-            // There is also no conflict because we asserted above that the parent is not
-            // assigned to false yet.
+            // assertion. An assertion never conflicts: it either re-asserts an already
+            // false parent or will assign the parent false during propagation.
             return (kind, None, false);
         };
 
@@ -200,14 +202,16 @@ impl<N: SolverId> Clause<N> {
             // Watch any candidate that is not assigned to false
             Some(watched_candidate) => (kind, Some([parent.negative(), watched_candidate]), false),
 
-            // All candidates are assigned to false! Therefore, the clause conflicts with the
-            // current decisions. There are no valid watches for it at the moment, but we will
-            // assign default ones nevertheless, because they will become valid after the solver
-            // restarts.
-            None => {
-                // Try to find a condition that is not assigned to false.
-                (kind, Some([parent.negative(), first_literal]), true)
-            }
+            // All candidates are assigned to false! Unless the parent is false as well
+            // (which satisfies the clause), the clause conflicts with the current
+            // decisions. There are no valid watches for it at the moment, but we will
+            // assign default ones nevertheless, because they will become valid after the
+            // solver restarts.
+            None => (
+                kind,
+                Some([parent.negative(), first_literal]),
+                !parent_is_false,
+            ),
         }
     }
 
@@ -228,14 +232,19 @@ impl<N: SolverId> Clause<N> {
         via: VersionSetId,
         decision_tracker: &DecisionTracker,
     ) -> (Self, Option<[Literal; 2]>, bool) {
-        // It only makes sense to introduce a constrains clause when the parent solvable
-        // is undecided or going to be installed
-        assert_ne!(decision_tracker.assigned_value(parent), Some(false));
+        // On the lazy-conditional path the parent may already have been propagated
+        // false by the time this clause is built (e.g. a candidate of a deferred
+        // requirement whose dependencies are prefetched). The clause `¬parent v
+        // ¬forbidden` is then currently satisfied, but the assignment can be
+        // backtracked later, so the clause must still be added.
+        let parent_is_false = decision_tracker.assigned_value(parent) == Some(false);
 
         // If the forbidden solvable is already assigned to true, that means that there
         // is a conflict with current decisions, because it implies the parent
-        // solvable would be false (and we just asserted that it is not)
-        let conflict = decision_tracker.assigned_value(forbidden_solvable) == Some(true);
+        // solvable would be false, unless the parent already is false, which
+        // satisfies the clause.
+        let conflict =
+            !parent_is_false && decision_tracker.assigned_value(forbidden_solvable) == Some(true);
 
         (
             Clause::Constrains(parent, forbidden_solvable, via),
@@ -266,14 +275,17 @@ impl<N: SolverId> Clause<N> {
         via: VersionSetId,
         decision_tracker: &DecisionTracker,
     ) -> (Self, Option<[Literal; 2]>, bool) {
-        // It only makes sense to introduce a constrains clause when the parent
-        // solvable is undecided or going to be installed
-        assert_ne!(decision_tracker.assigned_value(parent), Some(false));
+        // On the lazy-conditional path the parent may already have been propagated
+        // false by the time this clause is built (e.g. a candidate of a deferred
+        // requirement whose dependencies are prefetched). The clause `¬parent v
+        // ¬aux` is then currently satisfied, but the assignment can be backtracked
+        // later, so the clause must still be added.
+        let parent_is_false = decision_tracker.assigned_value(parent) == Some(false);
 
         // If the auxiliary variable is already true, an excluded candidate is
-        // installed, which implies the parent solvable would be false (and we
-        // just asserted that it is not).
-        let conflict = decision_tracker.assigned_value(aux) == Some(true);
+        // installed, which implies the parent solvable would be false, unless
+        // the parent already is false, which satisfies the clause.
+        let conflict = !parent_is_false && decision_tracker.assigned_value(aux) == Some(true);
 
         (
             Clause::ConstrainsParent(parent, aux, via),
@@ -915,21 +927,30 @@ mod test {
             candidate1
         );
 
-        // Panic
+        // No conflict: all candidates are false, but the parent is false as
+        // well, which satisfies the clause. This can happen on the
+        // lazy-conditional path where clauses are built after the parent was
+        // propagated false. The clause must still be constructed because the
+        // parent's assignment can be backtracked later.
         decisions
             .try_add_decision(Decision::new(parent, false, ClauseId::install_root()), 1)
             .unwrap();
-        let panicked = std::panic::catch_unwind(|| {
-            WatchedLiterals::requires::<crate::NameId>(
-                parent,
-                VersionSetId::from_index(0).into(),
-                [candidate1, candidate2],
-                None,
-                &decisions,
-            )
-        })
-        .is_err();
-        assert!(panicked);
+        let (clause, conflict, _kind) = WatchedLiterals::requires::<crate::NameId>(
+            parent,
+            VersionSetId::from_index(0).into(),
+            [candidate1, candidate2],
+            None,
+            &decisions,
+        );
+        assert!(!conflict);
+        assert_eq!(
+            clause.as_ref().unwrap().watched_literals[0].variable(),
+            parent
+        );
+        assert_eq!(
+            clause.as_ref().unwrap().watched_literals[1].variable(),
+            candidate1
+        );
     }
 
     #[test]
@@ -976,20 +997,29 @@ mod test {
             forbidden
         );
 
-        // Panic
+        // No conflict: the forbidden solvable is installed, but the parent is
+        // false, which satisfies the clause. This can happen on the
+        // lazy-conditional path where clauses are built after the parent was
+        // propagated false. The clause must still be constructed because the
+        // parent's assignment can be backtracked later.
         decisions
             .try_add_decision(Decision::new(parent, false, ClauseId::install_root()), 1)
             .unwrap();
-        let panicked = std::panic::catch_unwind(|| {
-            WatchedLiterals::constrains::<crate::NameId>(
-                parent,
-                forbidden,
-                VersionSetId::from_index(0),
-                &decisions,
-            )
-        })
-        .is_err();
-        assert!(panicked);
+        let (clause, conflict, _kind) = WatchedLiterals::constrains::<crate::NameId>(
+            parent,
+            forbidden,
+            VersionSetId::from_index(0),
+            &decisions,
+        );
+        assert!(!conflict);
+        assert_eq!(
+            clause.as_ref().unwrap().watched_literals[0].variable(),
+            parent
+        );
+        assert_eq!(
+            clause.as_ref().unwrap().watched_literals[1].variable(),
+            forbidden
+        );
     }
 
     #[test]

--- a/src/solver/conditions.rs
+++ b/src/solver/conditions.rs
@@ -57,11 +57,26 @@
 //! We add a requires clause for each disjunction in the boolean expression. So
 //! if we have the requirement `A requires B if C or D` we add requires clause
 //! for `A requires B if C` and for `A requires B if D`.
+//!
+//! ## Lazy candidate loading
+//!
+//! To avoid fetching candidates for requirements whose condition never fires
+//! the encoder may defer encoding a conditional requirement. When the encoder
+//! reaches such a requirement and the condition does not yet hold, the
+//! requirement is stored in [`crate::solver::SolverState::deferred_requirements`]
+//! and its requirement candidates are *not* fetched. The solver loop checks
+//! after each propagation whether any deferred condition has just started to
+//! hold; if so, the corresponding entry is drained from the deferred map and
+//! the encoder builds the requires clause exactly as the eager path would
+//! have. See [`DeferredRequirement`] and [`condition_disjunct_holds`].
 
 use std::num::NonZero;
 
 use crate::solver::clause::Literal;
-use crate::{Condition, ConditionId, DenseIndex, Interner, LogicalOperator, VersionSetId};
+use crate::{
+    Condition, ConditionId, ConditionalRequirement, DenseIndex, Interner, LogicalOperator,
+    VersionSetId, internal::solver_id::SolvableIdOrRoot,
+};
 
 /// An identifier that describes a group of version sets that are combined using
 /// AND logical operators.
@@ -119,4 +134,88 @@ pub fn convert_conditions_to_dnf<I: Interner>(
             result
         }
     }
+}
+
+/// One conjunct of a deferred condition disjunct. Captures the candidates
+/// needed to decide whether the conjunct currently holds.
+#[derive(Debug, Clone)]
+pub(crate) enum DeferredConjunct<S> {
+    /// The version set has a non-empty complement (some candidates of the
+    /// package do not match the version set). The conjunct holds when any of
+    /// the matching candidates of `version_set` is positively decided.
+    Solvables {
+        /// The version set inside the condition that this conjunct represents.
+        version_set: VersionSetId,
+        /// Candidates of the package that match `version_set`.
+        matching: Vec<S>,
+    },
+    /// The version set has an empty complement: every candidate of the package
+    /// matches it. The conjunct then holds whenever any candidate of the
+    /// package is positively decided.
+    Empty {
+        /// The version set inside the condition that this conjunct represents.
+        version_set: VersionSetId,
+        /// All candidates of the package whose version set was empty-complement.
+        all_candidates: Vec<S>,
+    },
+}
+
+impl<S> DeferredConjunct<S> {
+    /// The version set inside the condition that this conjunct represents.
+    pub fn version_set(&self) -> VersionSetId {
+        match self {
+            DeferredConjunct::Solvables { version_set, .. }
+            | DeferredConjunct::Empty { version_set, .. } => *version_set,
+        }
+    }
+
+    /// Candidates whose positive decision indicates that this conjunct holds.
+    pub fn candidates(&self) -> &[S] {
+        match self {
+            DeferredConjunct::Solvables { matching, .. } => matching,
+            DeferredConjunct::Empty { all_candidates, .. } => all_candidates,
+        }
+    }
+}
+
+/// A conditional requirement whose condition did not yet hold at the moment
+/// the encoder first reached it, and whose requirement candidates were
+/// therefore not loaded eagerly.
+///
+/// Each deferred entry corresponds to a *single* disjunct of the condition's
+/// DNF (a single `requires` clause in the encoding). Once that disjunct fires
+/// the entry is drained from
+/// [`crate::solver::SolverState::deferred_requirements`] and the requires
+/// clause is built. An entry is never encoded twice: removal happens on first
+/// fire.
+#[derive(Debug)]
+pub(crate) struct DeferredRequirement<S> {
+    /// The solvable whose dependencies introduced this requirement.
+    pub solvable_id: SolvableIdOrRoot<S>,
+    /// The conditional requirement itself; carries the requirement that needs
+    /// to be encoded once the condition fires.
+    pub requirement: ConditionalRequirement,
+    /// The condition that gates the requirement. Stored for use as the key in
+    /// the deferred map and for re-querying the cache when encoding.
+    pub condition: ConditionId,
+    /// The single disjunct of the condition's DNF that gates this entry. A
+    /// conjunction of `DeferredConjunct`; the disjunct holds when every
+    /// conjunct holds (see [`condition_disjunct_holds`]).
+    pub disjunct: Vec<DeferredConjunct<S>>,
+}
+
+/// Returns true if every conjunct in `disjunct` currently holds. A conjunct
+/// holds when at least one of its `candidates()` solvables has been
+/// positively decided in `is_positively_decided`. An empty disjunct (empty
+/// conjunction) is treated as trivially holding.
+pub(crate) fn condition_disjunct_holds<S: Copy>(
+    disjunct: &[DeferredConjunct<S>],
+    mut is_positively_decided: impl FnMut(S) -> bool,
+) -> bool {
+    disjunct.iter().all(|conjunct| {
+        conjunct
+            .candidates()
+            .iter()
+            .any(|&s| is_positively_decided(s))
+    })
 }

--- a/src/solver/decide_queue.rs
+++ b/src/solver/decide_queue.rs
@@ -1,0 +1,812 @@
+//! An incremental work queue for [`super::Solver::decide`].
+//!
+//! `decide()` must pick a candidate from a requires clause that is currently
+//! *eligible*: its parent is assigned true, its condition (if any) holds, and
+//! no candidate is assigned true yet. Only a small fraction of all requires
+//! clauses is eligible at any point, so instead of inspecting every clause on
+//! every call, this module tracks the eligible set incrementally and selects
+//! the best decision from it.
+//!
+//! - Every requires clause is registered as a [`TrackedClause`], identified
+//!   by its [`ClausePosition`]: the parent's registration index and the
+//!   clause's position in the parent's list. Both are append-only, so
+//!   positions are stable, and iterating clauses by position visits them in
+//!   a fixed, deterministic order.
+//! - [`DecideQueue::queue`] maps the position of each possibly-eligible
+//!   clause to its [`TrackedClauseId`]. It holds a *superset* of the
+//!   eligible clauses, restricted to clauses whose parent is assigned true:
+//!   clauses are removed only when an inspection in
+//!   [`DecideQueue::next_decision`] proves them ineligible, and every
+//!   assignment change that can make an unqueued clause eligible re-inserts
+//!   it through occurrence lists (see [`DecideQueue::sync`]).
+//! - [`DecideQueue::next_decision`] selects among the eligible clauses: it
+//!   takes the first eligible clause by position as the initial best and
+//!   then considers only the *hot* clauses after it. A clause replaces the
+//!   best only with strictly higher package activity; activities are
+//!   non-negative and a package that was never involved in a conflict has
+//!   activity exactly zero, so only clauses naming a package whose activity
+//!   was ever bumped (hot) can win. Hot clauses are mirrored in the much
+//!   smaller [`DecideQueue::hot_queue`].
+//!
+//! The selection heuristic lives only in `next_decision`; the
+//! heuristic-independent bookkeeping (wake-ups, caches, hot promotion) is
+//! verified on every call in debug builds by
+//! [`DecideQueue::debug_assert_invariants`], because a hole there does not
+//! crash or change solutions, it just silently degrades the search.
+
+use std::collections::BTreeMap;
+use std::ops::Bound;
+
+use ahash::HashMap;
+
+use crate::{
+    DependencyProvider, Requirement, VariableId, VersionSetId,
+    internal::{arena::Arena, id::ClauseId, small_vec::SmallVec},
+    requirement::RequirementMap,
+    solver_id::{IdMap, IdSet, SolverId},
+};
+
+use super::{
+    conditions::{Disjunction, DisjunctionId},
+    decision::Decision,
+    decision_map::DecisionMap,
+};
+
+/// Index of a [`TrackedClause`] in [`DecideQueue::clauses`].
+type TrackedClauseId = u32;
+
+/// The position of a requires clause in the queue's registration order: the
+/// parent's registration index in the high bits, the clause's position in
+/// the parent's list in the low bits. Comparing positions orders clauses by
+/// parent first and list order second, which is the order in which
+/// [`DecideQueue::next_decision`] considers them.
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+#[repr(transparent)]
+struct ClausePosition(u64);
+
+impl ClausePosition {
+    fn new(parent_pos: usize, clause_pos: usize) -> Self {
+        assert!(
+            parent_pos < u32::MAX as usize && clause_pos < u32::MAX as usize,
+            "clause position exceeds the packed u64 layout"
+        );
+        Self((parent_pos as u64) << 32 | clause_pos as u64)
+    }
+}
+
+/// A requires clause as tracked by the queue.
+#[derive(Copy, Clone)]
+struct TrackedClause {
+    position: ClausePosition,
+    parent: VariableId,
+    requirement: Requirement,
+    condition: Option<DisjunctionId>,
+    clause_id: ClauseId,
+    /// Whether any package name in the requirement has ever had its activity
+    /// bumped. Only hot clauses can replace a running best in
+    /// [`DecideQueue::next_decision`]; cold clauses have package activity
+    /// exactly zero.
+    hot: bool,
+}
+
+/// The cached result of walking a requirement's sorted candidate lists.
+///
+/// The walk depends only on the requirement and the current assignment, so it
+/// is cached per requirement and shared by all clauses with that requirement.
+/// Package activity is *not* cached; it is read fresh during selection.
+#[derive(Copy, Clone)]
+enum RequirementState {
+    /// Unknown: not yet evaluated, or a candidate assignment changed since
+    /// the last evaluation.
+    Dirty,
+    /// A candidate is assigned true, so every clause with this requirement is
+    /// satisfied. `by` acts like a satisfying watch literal: as long as it
+    /// stays true, changes to other candidates cannot break satisfaction.
+    Satisfied { by: VariableId },
+    /// No candidate is assigned true, and `candidate` is the first undecided
+    /// candidate in walk order. `count` is the number of undecided candidates
+    /// in the version set the first undecided candidate was found in.
+    Frontier {
+        candidate: VariableId,
+        version_set: VersionSetId,
+        count: u32,
+    },
+}
+
+struct RequirementEntry {
+    state: RequirementState,
+    /// Candidate occurrences are registered on the first evaluation; most
+    /// encoded requirements belong to solvables that are never installed and
+    /// are never evaluated. Before registration the entry is permanently
+    /// dirty, so a missed wake-up cannot lose information.
+    occurrences_registered: bool,
+}
+
+/// The decision produced by [`DecideQueue::next_decision`], including the
+/// heuristic inputs for tracing.
+pub(crate) struct QueueDecision {
+    pub candidate: VariableId,
+    pub required_by: VariableId,
+    pub clause_id: ClauseId,
+    pub package_activity: f32,
+    pub candidate_count: u32,
+}
+
+#[cfg(feature = "diagnostics")]
+#[derive(Default)]
+pub(crate) struct DecideQueueCounters {
+    /// Variables routed through the occurrence lists during sync.
+    pub sync_touches: u64,
+    /// Clauses removed from the queue after an inspection proved them
+    /// ineligible.
+    pub dequeues: u64,
+    /// Clause inspections during selection.
+    pub selection_visits: u64,
+    /// Inspections of hot clauses after the initial best.
+    pub hot_visits: u64,
+    /// Requirement walks actually evaluated (cache misses).
+    pub walk_evals: u64,
+}
+
+pub(crate) struct DecideQueue<D: DependencyProvider> {
+    /// All registered requires clauses, indexed by [`TrackedClauseId`].
+    clauses: Vec<TrackedClause>,
+    /// The registration index of each parent variable: the high half of the
+    /// [`ClausePosition`]s of its clauses, assigned on first registration.
+    parent_positions: HashMap<VariableId, u32>,
+    /// Clause ids per parent registration index.
+    clauses_by_parent: Vec<Vec<TrackedClauseId>>,
+
+    /// Position -> clause id for every possibly-eligible clause, ordered so
+    /// that iteration visits clauses in their fixed selection order.
+    queue: BTreeMap<ClausePosition, TrackedClauseId>,
+    /// The subset of `queue` whose clauses are hot, maintained in lockstep.
+    hot_queue: BTreeMap<ClausePosition, TrackedClauseId>,
+
+    /// Names whose activity was ever bumped. Never shrinks: decay can bring
+    /// an activity back to zero, which only makes the hot set a conservative
+    /// superset.
+    hot_names: <D::NameId as SolverId>::Set,
+    /// Name -> clauses whose requirement mentions that name, used to promote
+    /// clauses when a name first becomes hot.
+    clauses_by_name: HashMap<D::NameId, Vec<TrackedClauseId>>,
+
+    /// Candidate variable -> requirements whose walk inspected it. Registered
+    /// lazily on a requirement's first evaluation.
+    requirements_by_candidate: HashMap<VariableId, SmallVec<Requirement>>,
+    /// Condition variable -> clauses whose condition disjunction mentions it.
+    clauses_by_condition_variable: HashMap<VariableId, Vec<TrackedClauseId>>,
+
+    /// The walk cache, one entry per requirement.
+    requirement_states: RequirementMap<RequirementEntry>,
+    /// Requirement -> clauses with that requirement, woken when the
+    /// requirement's satisfaction breaks.
+    clauses_by_requirement: RequirementMap<Vec<TrackedClauseId>>,
+
+    /// The variables of the solver's trail (the chronological assignment log
+    /// in [`super::decision_tracker::DecisionTracker`]) as they were at the
+    /// previous [`Self::sync`]. Comparing this snapshot against the current
+    /// trail tells the queue which variables changed in between.
+    mirror: Vec<VariableId>,
+
+    /// When true (the default; requires `activity_add > 0` and
+    /// `activity_decay >= 0`) the selection only visits hot clauses after the
+    /// first eligible one and may stop early on activity grounds. With
+    /// non-standard activity parameters the non-negativity argument breaks
+    /// down, so the selection visits every eligible clause instead.
+    hot_only: bool,
+
+    #[cfg(feature = "diagnostics")]
+    pub(crate) counters: DecideQueueCounters,
+}
+
+impl<D: DependencyProvider> Default for DecideQueue<D> {
+    fn default() -> Self {
+        Self {
+            clauses: Vec::new(),
+            parent_positions: HashMap::default(),
+            clauses_by_parent: Vec::new(),
+            queue: BTreeMap::new(),
+            hot_queue: BTreeMap::new(),
+            hot_names: Default::default(),
+            clauses_by_name: HashMap::default(),
+            requirements_by_candidate: HashMap::default(),
+            clauses_by_condition_variable: HashMap::default(),
+            requirement_states: RequirementMap::default(),
+            clauses_by_requirement: RequirementMap::default(),
+            mirror: Vec::new(),
+            hot_only: true,
+            #[cfg(feature = "diagnostics")]
+            counters: DecideQueueCounters::default(),
+        }
+    }
+}
+
+/// Inserts a clause into the queue (and the hot queue if it is hot), unless
+/// its parent is not currently assigned true. Filtering on the parent here
+/// keeps the constant churn of candidate variables being forbidden from ever
+/// touching the queue.
+fn enqueue_clause(
+    queue: &mut BTreeMap<ClausePosition, TrackedClauseId>,
+    hot_queue: &mut BTreeMap<ClausePosition, TrackedClauseId>,
+    clauses: &[TrackedClause],
+    map: &DecisionMap,
+    id: TrackedClauseId,
+) {
+    let clause = &clauses[id as usize];
+    if map.value(clause.parent) != Some(true) {
+        return;
+    }
+    queue.insert(clause.position, id);
+    if clause.hot {
+        hot_queue.insert(clause.position, id);
+    }
+}
+
+impl<D: DependencyProvider> DecideQueue<D> {
+    /// Configures whether the activity-based selection shortcuts are sound
+    /// for the solver's activity parameters. See [`Self::hot_only`].
+    pub(crate) fn set_standard_activity_params(&mut self, standard: bool) {
+        self.hot_only = standard;
+    }
+
+    /// Registers a newly encoded requires clause. Must be called exactly once
+    /// per requires clause, in encoding order.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn register_clause(
+        &mut self,
+        parent: VariableId,
+        requirement: Requirement,
+        condition: Option<DisjunctionId>,
+        clause_id: ClauseId,
+        names: impl IntoIterator<Item = D::NameId>,
+        disjunctions: &Arena<DisjunctionId, Disjunction>,
+        parent_value: Option<bool>,
+    ) {
+        let parent_pos = *self.parent_positions.entry(parent).or_insert_with(|| {
+            self.clauses_by_parent.push(Vec::new());
+            (self.clauses_by_parent.len() - 1) as u32
+        }) as usize;
+        let clause_pos = self.clauses_by_parent[parent_pos].len();
+        let position = ClausePosition::new(parent_pos, clause_pos);
+        let id = self.clauses.len() as TrackedClauseId;
+
+        // A union can mention the same package in several version sets;
+        // dedup so the occurrence lists hold each clause once.
+        let mut hot = false;
+        let mut seen_names: SmallVec<D::NameId> = SmallVec::empty();
+        for name in names {
+            if seen_names.as_slice().contains(&name) {
+                continue;
+            }
+            seen_names.push(name);
+            if self.hot_names.contains(name) {
+                hot = true;
+            }
+            self.clauses_by_name.entry(name).or_default().push(id);
+        }
+
+        if let Some(condition) = condition {
+            for literal in &disjunctions[condition].literals {
+                self.clauses_by_condition_variable
+                    .entry(literal.variable())
+                    .or_default()
+                    .push(id);
+            }
+        }
+
+        self.requirement_states
+            .get_or_insert_with(requirement, || RequirementEntry {
+                state: RequirementState::Dirty,
+                occurrences_registered: false,
+            });
+        self.clauses_by_requirement
+            .get_or_insert_with(requirement, Vec::new)
+            .push(id);
+
+        self.clauses_by_parent[parent_pos].push(id);
+
+        self.clauses.push(TrackedClause {
+            position,
+            parent,
+            requirement,
+            condition,
+            clause_id,
+            hot,
+        });
+
+        if parent_value == Some(true) {
+            self.queue.insert(position, id);
+            if hot {
+                self.hot_queue.insert(position, id);
+            }
+        }
+    }
+
+    /// Marks a package name as hot (its activity was bumped) and promotes the
+    /// queued clauses that mention it into the hot queue. Names never become
+    /// cold again.
+    pub(crate) fn mark_name_hot(&mut self, name: D::NameId) {
+        if !self.hot_names.insert(name) {
+            return;
+        }
+        let Some(ids) = self.clauses_by_name.get(&name) else {
+            return;
+        };
+        for &id in ids {
+            let clause = &mut self.clauses[id as usize];
+            if clause.hot {
+                continue;
+            }
+            clause.hot = true;
+            let position = clause.position;
+            if let Some(&queued) = self.queue.get(&position) {
+                self.hot_queue.insert(position, queued);
+            }
+        }
+    }
+
+    /// Brings the queue up to date with all assignment changes since the
+    /// previous call, routing every changed variable through the occurrence
+    /// lists.
+    ///
+    /// `trail` is the solver's chronological assignment log: propagation
+    /// pushes onto it and backtracking pops from it, so it only ever changes
+    /// at its end. [`Self::mirror`] holds the trail variables as of the
+    /// previous sync, and `floor` (from
+    /// [`super::decision_tracker::DecisionTracker::take_sync_floor`]) is the
+    /// lowest trail length reached since then. That splits both snapshots in
+    /// three:
+    ///
+    /// - `[..floor]` is identical in the mirror and the trail: untouched, no
+    ///   work.
+    /// - `mirror[floor..]` was popped at some point: each variable may be
+    ///   unassigned now, or reassigned at a different trail position.
+    /// - `trail[floor..]` was pushed since: newly assigned variables.
+    ///
+    /// Variables in the last two ranges are re-routed (a variable can appear
+    /// in both; routing is idempotent). An assignment that was both pushed
+    /// and popped between the two calls falls in neither range: it has no net
+    /// effect on the assignment, and the queue only compares snapshots, so it
+    /// is correct to never see it.
+    pub(crate) fn sync(&mut self, floor: usize, trail: &[Decision], map: &DecisionMap) {
+        for i in floor..self.mirror.len() {
+            let variable = self.mirror[i];
+            self.route_touched(variable, map);
+        }
+        self.mirror.truncate(floor);
+        for decision in &trail[floor..] {
+            self.mirror.push(decision.variable);
+            self.route_touched(decision.variable, map);
+        }
+    }
+
+    /// Routes one variable whose assignment may have changed through the
+    /// occurrence lists, re-inserting clauses that may have become eligible
+    /// and invalidating requirement walk caches.
+    fn route_touched(&mut self, variable: VariableId, map: &DecisionMap) {
+        #[cfg(feature = "diagnostics")]
+        {
+            self.counters.sync_touches += 1;
+        }
+
+        let Self {
+            clauses,
+            parent_positions,
+            clauses_by_parent,
+            queue,
+            hot_queue,
+            requirements_by_candidate,
+            clauses_by_condition_variable,
+            requirement_states,
+            clauses_by_requirement,
+            ..
+        } = self;
+
+        let value = map.value(variable);
+
+        // Parent wake-up: a clause can only become eligible when its parent
+        // is assigned true; any other value keeps it ineligible.
+        if value == Some(true) {
+            if let Some(&parent_pos) = parent_positions.get(&variable) {
+                for &id in &clauses_by_parent[parent_pos as usize] {
+                    enqueue_clause(queue, hot_queue, clauses, map, id);
+                }
+            }
+        }
+
+        // Candidate wake-up: invalidate the walk caches of the requirements
+        // that inspected this variable, and wake clauses whose satisfaction
+        // broke. Frontier entries are only dirtied: a frontier requirement's
+        // eligible clauses are still queued (the selection only dequeues
+        // clauses of satisfied requirements; parent and condition dequeues
+        // are woken by their own lists).
+        if let Some(requirements) = requirements_by_candidate.get(&variable) {
+            for &requirement in requirements.as_slice() {
+                let entry = requirement_states
+                    .get_mut(requirement)
+                    .expect("occurrence-registered requirement has a cache entry");
+                match entry.state {
+                    RequirementState::Dirty => {}
+                    RequirementState::Frontier { .. } => entry.state = RequirementState::Dirty,
+                    RequirementState::Satisfied { by } => {
+                        if map.value(by) == Some(true) {
+                            // The satisfying candidate is still true; the
+                            // clause stays satisfied regardless of this
+                            // variable.
+                            continue;
+                        }
+                        entry.state = RequirementState::Dirty;
+                        if let Some(woken) = clauses_by_requirement.get(requirement) {
+                            for &id in woken {
+                                enqueue_clause(queue, hot_queue, clauses, map, id);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Condition wake-up: condition literals carry polarity, so any change
+        // (in either direction) can complete an all-false condition.
+        if let Some(woken) = clauses_by_condition_variable.get(&variable) {
+            for &id in woken {
+                enqueue_clause(queue, hot_queue, clauses, map, id);
+            }
+        }
+    }
+
+    /// Evaluates a requirement through the per-requirement cache by walking
+    /// its sorted candidate lists: returns the satisfying candidate if one is
+    /// assigned true, or the first undecided candidate, its version set, and
+    /// the number of undecided candidates in that version set.
+    fn eval_requirement(
+        requirement_states: &mut RequirementMap<RequirementEntry>,
+        requirements_by_candidate: &mut HashMap<VariableId, SmallVec<Requirement>>,
+        requirement: Requirement,
+        map: &DecisionMap,
+        sorted_candidates: &RequirementMap<Vec<Vec<VariableId>>>,
+        provider: &D,
+        #[cfg(feature = "diagnostics")] counters: &mut DecideQueueCounters,
+    ) -> RequirementState {
+        let entry = requirement_states
+            .get_mut(requirement)
+            .expect("every registered clause created a cache entry");
+        if !matches!(entry.state, RequirementState::Dirty) {
+            return entry.state;
+        }
+
+        #[cfg(feature = "diagnostics")]
+        {
+            counters.walk_evals += 1;
+        }
+
+        let version_set_candidates = &sorted_candidates[requirement];
+
+        if !entry.occurrences_registered {
+            entry.occurrences_registered = true;
+            for &candidate in version_set_candidates.iter().flatten() {
+                requirements_by_candidate
+                    .entry(candidate)
+                    .or_insert_with(SmallVec::empty)
+                    .push(requirement);
+            }
+        }
+
+        let mut first: Option<(VariableId, VersionSetId, u32)> = None;
+        'walk: for (version_set, candidates) in requirement
+            .version_sets(provider)
+            .zip(version_set_candidates)
+        {
+            for &candidate in candidates {
+                match map.value(candidate) {
+                    Some(true) => {
+                        entry.state = RequirementState::Satisfied { by: candidate };
+                        break 'walk;
+                    }
+                    Some(false) => {}
+                    None => match first.as_mut() {
+                        Some((_, first_version_set, count)) => {
+                            if *first_version_set == version_set {
+                                *count += 1;
+                            }
+                        }
+                        None => first = Some((candidate, version_set, 1)),
+                    },
+                }
+            }
+        }
+
+        if matches!(entry.state, RequirementState::Dirty) {
+            let Some((candidate, version_set, count)) = first else {
+                unreachable!(
+                    "when we get here it means that all candidates have been assigned false. This should not be able to happen at this point because during propagation the solvable should have been assigned false as well."
+                )
+            };
+            entry.state = RequirementState::Frontier {
+                candidate,
+                version_set,
+                count,
+            };
+        }
+        entry.state
+    }
+
+    /// Checks whether a clause is eligible at the current assignment
+    /// snapshot. Returns the requirement frontier if it is.
+    fn inspect(
+        &mut self,
+        clause: TrackedClause,
+        map: &DecisionMap,
+        sorted_candidates: &RequirementMap<Vec<Vec<VariableId>>>,
+        disjunctions: &Arena<DisjunctionId, Disjunction>,
+        provider: &D,
+    ) -> Option<(VariableId, VersionSetId, u32)> {
+        #[cfg(feature = "diagnostics")]
+        {
+            self.counters.selection_visits += 1;
+        }
+
+        // Consider only clauses in which we have decided to install the
+        // parent solvable.
+        if map.value(clause.parent) != Some(true) {
+            return None;
+        }
+
+        // If the clause has a condition that is not yet satisfied we need to
+        // skip it.
+        if let Some(condition) = clause.condition {
+            let literals = &disjunctions[condition].literals;
+            if !literals.iter().all(|c| c.eval(map) == Some(false)) {
+                return None;
+            }
+        }
+
+        match Self::eval_requirement(
+            &mut self.requirement_states,
+            &mut self.requirements_by_candidate,
+            clause.requirement,
+            map,
+            sorted_candidates,
+            provider,
+            #[cfg(feature = "diagnostics")]
+            &mut self.counters,
+        ) {
+            RequirementState::Satisfied { .. } => None,
+            RequirementState::Frontier {
+                candidate,
+                version_set,
+                count,
+            } => Some((candidate, version_set, count)),
+            RequirementState::Dirty => {
+                unreachable!("eval_requirement never leaves the entry dirty")
+            }
+        }
+    }
+
+    /// Selects the best decision among the eligible clauses, visiting them in
+    /// position order: the first eligible clause is the initial best, and a
+    /// later clause replaces it only with strictly higher package activity
+    /// and strictly fewer remaining candidates (clauses of the root are
+    /// always preferred over the rest). Ineligible clauses reached on the way
+    /// are dequeued, which is what keeps the queue tight.
+    ///
+    /// `max_activity` must be exactly the largest activity stored in
+    /// `name_activity` (it is maintained next to the bumps and decays).
+    pub(crate) fn next_decision(
+        &mut self,
+        map: &DecisionMap,
+        sorted_candidates: &RequirementMap<Vec<Vec<VariableId>>>,
+        disjunctions: &Arena<DisjunctionId, Disjunction>,
+        name_activity: &<D::NameId as SolverId>::Map<f32>,
+        max_activity: f32,
+        provider: &D,
+    ) -> Option<QueueDecision> {
+        struct Best {
+            position: ClausePosition,
+            explicit: bool,
+            activity: f32,
+            count: u32,
+            decision: (VariableId, VariableId, ClauseId),
+        }
+
+        let hot_only = self.hot_only;
+        // Replacement requires strictly fewer candidates than the best (so a
+        // count of one is unbeatable) and, with standard activity parameters,
+        // strictly higher activity (so the global maximum is unbeatable).
+        let unbeatable =
+            |best: &Best| best.count == 1 || (hot_only && best.activity == max_activity);
+
+        // The first eligible clause in position order is the initial best.
+        // Ineligible clauses reached on the way are dequeued (amortized
+        // against their insertions).
+        let mut best: Option<Best> = None;
+        while let Some((&position, &id)) = self.queue.first_key_value() {
+            let clause = self.clauses[id as usize];
+            match self.inspect(clause, map, sorted_candidates, disjunctions, provider) {
+                None => {
+                    self.queue.pop_first();
+                    self.hot_queue.remove(&position);
+                    #[cfg(feature = "diagnostics")]
+                    {
+                        self.counters.dequeues += 1;
+                    }
+                }
+                Some((candidate, version_set, count)) => {
+                    let activity = name_activity.get(provider.version_set_name(version_set));
+                    best = Some(Best {
+                        position,
+                        explicit: clause.parent == VariableId::root(),
+                        activity,
+                        count,
+                        decision: (candidate, clause.parent, clause.clause_id),
+                    });
+                    break;
+                }
+            }
+        }
+        let mut best = best?;
+
+        // Try to replace the best with an eligible clause after it. With
+        // standard activity parameters only hot clauses can win, so only the
+        // much smaller hot queue is visited.
+        if !unbeatable(&best) {
+            let mut cursor = best.position;
+            loop {
+                let next = if hot_only {
+                    self.hot_queue
+                        .range((Bound::Excluded(cursor), Bound::Unbounded))
+                        .next()
+                } else {
+                    self.queue
+                        .range((Bound::Excluded(cursor), Bound::Unbounded))
+                        .next()
+                }
+                .map(|(&position, &id)| (position, id));
+                let Some((position, id)) = next else {
+                    break;
+                };
+                cursor = position;
+
+                let clause = self.clauses[id as usize];
+                let is_explicit = clause.parent == VariableId::root();
+
+                // Decisions on explicit requirements (clauses of the root)
+                // are preferred over non-explicit requirements; such clauses
+                // are skipped without an eligibility inspection and stay
+                // queued.
+                if best.explicit && !is_explicit {
+                    continue;
+                }
+
+                #[cfg(feature = "diagnostics")]
+                {
+                    self.counters.hot_visits += 1;
+                }
+
+                match self.inspect(clause, map, sorted_candidates, disjunctions, provider) {
+                    None => {
+                        self.queue.remove(&position);
+                        self.hot_queue.remove(&position);
+                        #[cfg(feature = "diagnostics")]
+                        {
+                            self.counters.dequeues += 1;
+                        }
+                    }
+                    Some((candidate, version_set, count)) => {
+                        let activity = name_activity.get(provider.version_set_name(version_set));
+
+                        // Prefer a higher package activity score to root out
+                        // conflicts faster, and fewer remaining candidates to
+                        // reduce backtracking. Both must improve strictly.
+                        if best.activity >= activity {
+                            continue;
+                        }
+                        if best.count <= count {
+                            continue;
+                        }
+
+                        best = Best {
+                            position,
+                            explicit: is_explicit,
+                            activity,
+                            count,
+                            decision: (candidate, clause.parent, clause.clause_id),
+                        };
+                        if unbeatable(&best) {
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        let (candidate, required_by, clause_id) = best.decision;
+        Some(QueueDecision {
+            candidate,
+            required_by,
+            clause_id,
+            package_activity: best.activity,
+            candidate_count: best.count,
+        })
+    }
+
+    /// Verifies the heuristic-independent queue invariants. Called on every
+    /// `decide()` in debug builds; a violation means a wake-up, cache, or hot
+    /// promotion hole, which would otherwise only show up as silently
+    /// different decisions (the solver stays sound under any decision order).
+    ///
+    /// Must run after [`Self::sync`]; [`Self::next_decision`] only ever
+    /// dequeues ineligible clauses, so the invariants hold before and after
+    /// it.
+    #[cfg(debug_assertions)]
+    pub(crate) fn debug_assert_invariants(
+        &self,
+        map: &DecisionMap,
+        sorted_candidates: &RequirementMap<Vec<Vec<VariableId>>>,
+        disjunctions: &Arena<DisjunctionId, Disjunction>,
+        name_activity: &<D::NameId as SolverId>::Map<f32>,
+        max_activity: f32,
+        provider: &D,
+    ) {
+        // Every eligible clause is queued. Eligibility is recomputed from
+        // first principles, without the caches or the heuristic.
+        for (id, clause) in self.clauses.iter().enumerate() {
+            if map.value(clause.parent) != Some(true) {
+                continue;
+            }
+            if let Some(condition) = clause.condition {
+                let literals = &disjunctions[condition].literals;
+                if !literals.iter().all(|c| c.eval(map) == Some(false)) {
+                    continue;
+                }
+            }
+            let satisfied = sorted_candidates[clause.requirement]
+                .iter()
+                .flatten()
+                .any(|&candidate| map.value(candidate) == Some(true));
+            if satisfied {
+                continue;
+            }
+            assert!(
+                self.queue.contains_key(&clause.position),
+                "eligible requires clause {id} is not queued"
+            );
+        }
+
+        // Hot flags match the hot name set, and the hot queue mirrors the
+        // queue for hot clauses.
+        for (id, clause) in self.clauses.iter().enumerate() {
+            let should_be_hot = clause
+                .requirement
+                .version_sets(provider)
+                .any(|version_set| {
+                    self.hot_names
+                        .contains(provider.version_set_name(version_set))
+                });
+            assert_eq!(
+                clause.hot, should_be_hot,
+                "clause {id} hot flag out of sync with the hot name set"
+            );
+            if clause.hot {
+                assert_eq!(
+                    self.queue.contains_key(&clause.position),
+                    self.hot_queue.contains_key(&clause.position),
+                    "hot queue out of lockstep for clause {id}"
+                );
+            }
+        }
+
+        // The early stop relies on `max_activity` being exactly the largest
+        // stored activity. Only meaningful with standard activity parameters
+        // (the stop is disabled otherwise).
+        if self.hot_only {
+            let mut actual_max = 0.0f32;
+            name_activity.for_each(|&activity| actual_max = actual_max.max(activity));
+            assert_eq!(
+                max_activity, actual_max,
+                "max_activity diverged from the largest stored activity"
+            );
+        }
+    }
+}

--- a/src/solver/decision_tracker.rs
+++ b/src/solver/decision_tracker.rs
@@ -6,8 +6,26 @@ use crate::{VariableId, internal::id::ClauseId};
 #[derive(Default)]
 pub(crate) struct DecisionTracker {
     map: DecisionMap,
+
+    /// The *trail*: every assignment in the chronological order it was made,
+    /// both decisions and propagated assignments. Assigning pushes onto it
+    /// and backtracking pops from it, so the trail only ever changes at its
+    /// end: two snapshots of the trail always share a common prefix up to
+    /// the minimum length reached in between.
     stack: Vec<Decision>,
+
     propagate_index: usize,
+
+    /// The minimum length of `stack` since the last call to
+    /// [`Self::take_sync_floor`]: the length of the trail prefix that is
+    /// guaranteed unchanged since then. [`crate::solver::decide_queue`] keeps
+    /// a copy of the trail and uses the floor to find what changed: copied
+    /// entries at or beyond the floor have been popped at some point (their
+    /// variables may be unassigned now or reassigned elsewhere), and current
+    /// `stack` entries at or beyond it were pushed since. An assignment that
+    /// was both pushed and popped in between is in neither range; it has no
+    /// net effect, so a consumer comparing snapshots never needs to see it.
+    sync_floor: usize,
 }
 
 impl DecisionTracker {
@@ -32,6 +50,21 @@ impl DecisionTracker {
 
     pub(crate) fn stack(&self) -> impl DoubleEndedIterator<Item = Decision> + '_ {
         self.stack.iter().copied()
+    }
+
+    /// Returns the current decision stack as a slice.
+    pub(crate) fn assignments(&self) -> &[Decision] {
+        &self.stack
+    }
+
+    /// Returns the minimum trail length reached since the previous call (or
+    /// since construction) and resets the floor to the current trail length.
+    ///
+    /// The trail up to the returned floor is unchanged since the previous
+    /// call; everything a snapshot-comparing consumer has to look at lies at
+    /// or beyond it. See [`Self::sync_floor`].
+    pub(crate) fn take_sync_floor(&mut self) -> usize {
+        std::mem::replace(&mut self.sync_floor, self.stack.len())
     }
 
     pub(crate) fn level(&self, variable_id: VariableId) -> u32 {
@@ -85,6 +118,7 @@ impl DecisionTracker {
         self.map.reset(decision.variable);
 
         self.propagate_index = self.stack.len();
+        self.sync_floor = self.sync_floor.min(self.stack.len());
 
         let top_decision = self.stack.last().unwrap();
         (decision, self.map.level(top_decision.variable))
@@ -98,5 +132,54 @@ impl DecisionTracker {
         let &decision = self.stack[self.propagate_index..].iter().next()?;
         self.propagate_index += 1;
         Some(decision)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::DenseIndex;
+
+    fn var(i: usize) -> VariableId {
+        VariableId::from_index(i)
+    }
+
+    fn push(tracker: &mut DecisionTracker, i: usize, level: u32) {
+        tracker
+            .try_add_decision(Decision::new(var(i), true, ClauseId::install_root()), level)
+            .unwrap();
+    }
+
+    #[test]
+    fn take_sync_floor_tracks_minimum_stack_length() {
+        let mut tracker = DecisionTracker::default();
+        assert_eq!(tracker.take_sync_floor(), 0);
+
+        push(&mut tracker, 0, 1);
+        push(&mut tracker, 1, 2);
+        push(&mut tracker, 2, 2);
+        assert_eq!(tracker.take_sync_floor(), 0);
+
+        // An assignment made and undone between two observations cancels out:
+        // the floor only drops to the minimum length reached.
+        tracker.undo_last();
+        push(&mut tracker, 3, 2);
+        assert_eq!(tracker.take_sync_floor(), 2);
+
+        // Two undos followed by new pushes report the deepest undo.
+        tracker.undo_last();
+        tracker.undo_last();
+        push(&mut tracker, 4, 2);
+        push(&mut tracker, 5, 2);
+        assert_eq!(tracker.take_sync_floor(), 1);
+
+        // Pushes alone never lower the floor: it stays at the stack length
+        // observed by the previous take (3), not the current length (4).
+        push(&mut tracker, 6, 2);
+        assert_eq!(tracker.take_sync_floor(), 3);
+
+        // Clearing resets the floor to zero.
+        tracker.clear();
+        assert_eq!(tracker.take_sync_floor(), 0);
     }
 }

--- a/src/solver/diagnostics.rs
+++ b/src/solver/diagnostics.rs
@@ -216,6 +216,19 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
             .unwrap();
         }
 
+        let queue_counters = &self.state.decide_queue.counters;
+        writeln!(writer, "\n=== Decide Queue ===").unwrap();
+        writeln!(writer, "Sync touches:\t{}", queue_counters.sync_touches).unwrap();
+        writeln!(
+            writer,
+            "Selection visits:\t{}",
+            queue_counters.selection_visits
+        )
+        .unwrap();
+        writeln!(writer, "- Hot:\t{}", queue_counters.hot_visits).unwrap();
+        writeln!(writer, "Dequeues:\t{}", queue_counters.dequeues).unwrap();
+        writeln!(writer, "Walk evaluations:\t{}", queue_counters.walk_evals).unwrap();
+
         writeln!(writer, "\n=== Phase Timing ===").unwrap();
         writeln!(
             writer,

--- a/src/solver/diagnostics.rs
+++ b/src/solver/diagnostics.rs
@@ -188,6 +188,13 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
         )
         .unwrap();
         writeln!(writer, "Conflicts:\t{}", counters.conflicts).unwrap();
+        writeln!(writer, "Restarts:\t{}", counters.restarts).unwrap();
+        writeln!(
+            writer,
+            "Restart suppressions:\t{}",
+            counters.restart_suppressions
+        )
+        .unwrap();
 
         writeln!(writer, "\nClause visits by type:").unwrap();
         let vbt = &counters.visits_by_type;

--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -404,11 +404,17 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
             );
             let clause_id = self.state.add_clause(watched_literals, kind);
 
-            self.state
-                .requires_clauses
-                .entry(variable)
-                .or_default()
-                .push((requirement.requirement, condition, clause_id));
+            let names = requirement
+                .requirement
+                .version_sets(self.cache.provider())
+                .map(|version_set| self.cache.provider().version_set_name(version_set));
+            self.state.add_requires_clause(
+                variable,
+                requirement.requirement,
+                condition,
+                clause_id,
+                names,
+            );
 
             if conflict {
                 self.conflicting_clauses.push(clause_id);

--- a/src/solver/encoding.rs
+++ b/src/solver/encoding.rs
@@ -1,11 +1,14 @@
-use std::{any::Any, collections::VecDeque, future::ready};
+use std::{any::Any, collections::VecDeque};
 
 use super::{SolverState, clause::WatchedLiterals, conditions};
 use crate::{
     Candidates, ConditionId, ConditionalRequirement, DenseIndex, Dependencies, DependencyProvider,
     SolverCache, StringId, VariableId, VersionSetId,
     internal::{id::ClauseId, solver_id::SolvableIdOrRoot},
-    solver::{conditions::Disjunction, decision::Decision},
+    solver::{
+        conditions::{DeferredConjunct, DeferredRequirement, Disjunction},
+        decision::Decision,
+    },
     solver_id::{IdMap, IdSet},
     utils::IndexedSet,
 };
@@ -65,6 +68,10 @@ pub(crate) struct Encoder<'a, 'cache, D: DependencyProvider> {
 enum TaskResult<'a, D: DependencyProvider> {
     Dependencies(DependenciesAvailable<'a, D::SolvableId>),
     Candidates(CandidatesAvailable<'a, D>),
+    /// The condition data for a conditional requirement is available. The
+    /// encoder uses this to decide whether to load the requirement's
+    /// candidates eagerly or defer them until the condition fires.
+    ConditionData(ConditionDataAvailable<'a, D::SolvableId>),
     RequirementCandidates(RequirementCandidatesAvailable<'a, D>),
     ConstraintCandidates(ConstraintCandidatesAvailable<'a, D::SolvableId>),
 }
@@ -81,11 +88,42 @@ struct CandidatesAvailable<'a, D: DependencyProvider> {
     package_candidates: &'a Candidates<D::SolvableId>,
 }
 
+/// Result of querying the condition data for a conditional requirement. The
+/// data is split per disjunct of the condition's DNF; each disjunct carries
+/// both the matching candidates (for the fire check) and the complement
+/// candidates (for the requires-clause literals).
+struct ConditionDataAvailable<'a, S> {
+    solvable_id: SolvableIdOrRoot<S>,
+    requirement: ConditionalRequirement,
+    condition: ConditionId,
+    disjuncts: Vec<DisjunctData<'a, S>>,
+}
+
+/// One disjunct of a condition's DNF resolved against the cache: each conjunct
+/// VS has its matching candidates (used to decide if the disjunct currently
+/// holds) and its complement representation (used to build the requires
+/// clause).
+struct DisjunctData<'a, S> {
+    conjuncts: Vec<ConjunctData<'a, S>>,
+}
+
+struct ConjunctData<'a, S> {
+    /// Candidates of the package matching the conjunct's version set. Used
+    /// for the fire check; the version set itself is carried inside the
+    /// complement form below for the encoding step.
+    matching: &'a [S],
+    /// The complement form used for the requires-clause literals.
+    complement: DisjunctionComplement<'a, S>,
+}
+
 /// Result of querying candidates for a particular requirement.
 struct RequirementCandidatesAvailable<'a, D: DependencyProvider> {
     solvable_id: SolvableIdOrRoot<D::SolvableId>,
     requirement: ConditionalRequirement,
     candidates: Vec<&'a [D::SolvableId]>,
+    /// The condition data for this requirement, already filtered to the
+    /// disjuncts that should be encoded right now. For an unconditional
+    /// requirement this is `None`.
     condition: RequirementCondition<'a, D::SolvableId>,
 }
 
@@ -154,12 +192,29 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
 
     /// Encode rules and variables for the given solvables.
     pub async fn encode(
+        self,
+        solvable_ids: impl IntoIterator<Item = SolvableIdOrRoot<D::SolvableId>>,
+    ) -> Result<Vec<ClauseId>, Box<dyn Any>> {
+        self.encode_with_deferred(solvable_ids, Vec::new()).await
+    }
+
+    /// Encode rules and variables for the given solvables, additionally
+    /// processing deferred conditional requirements whose condition just
+    /// fired. Each deferred entry is encoded into a single requires clause,
+    /// fetching its requirement candidates lazily.
+    pub async fn encode_with_deferred(
         mut self,
         solvable_ids: impl IntoIterator<Item = SolvableIdOrRoot<D::SolvableId>>,
+        deferred: Vec<DeferredRequirement<D::SolvableId>>,
     ) -> Result<Vec<ClauseId>, Box<dyn Any>> {
         // Queue the initial solvables for processing.
         for solvable_id in solvable_ids {
             self.queue_solvable(solvable_id);
+        }
+
+        // Queue deferred requirements that just had their condition fire.
+        for entry in deferred {
+            self.queue_deferred_requirement(entry);
         }
 
         // Process pending work until none remains. Immediately completed
@@ -189,6 +244,7 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
         match result {
             TaskResult::Dependencies(dependencies) => self.on_dependencies_available(dependencies),
             TaskResult::Candidates(candidates) => self.on_candidates_available(candidates),
+            TaskResult::ConditionData(data) => self.on_condition_data_available(data),
             TaskResult::RequirementCandidates(candidates) => {
                 self.on_requirement_candidates_available(candidates)
             }
@@ -228,10 +284,15 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
             }
         };
 
-        // Iterate over all requirements and find out to which packages they
-        // refer. Make sure we have all candidates for a particular package.
+        // Make sure we have all candidates for each package referenced by
+        // unconditional requirements and by constraints. Packages reachable
+        // *only* through a conditional requirement are not enqueued here;
+        // their candidates are loaded lazily in the deferred path once the
+        // condition fires (see [`Self::on_condition_data_available`] and
+        // [`Self::queue_deferred_requirement`]).
         for version_set_id in requirements
             .iter()
+            .filter(|requirement| requirement.condition.is_none())
             .flat_map(|requirement| requirement.requirement.version_sets(self.cache.provider()))
             .chain(constraints.iter().copied())
         {
@@ -295,6 +356,13 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
         );
 
         let variable = self.state.variable_map.intern_solvable_or_root(solvable_id);
+
+        // Note: on the lazy-conditional path the parent may already have been
+        // propagated false (e.g. a deferred requirement whose condition fires
+        // after the parent was forbidden). The clause is still encoded: the
+        // parent's assignment can be backtracked later, and since neither the
+        // drained deferred entry nor `clauses_added_for_solvable` is revisited,
+        // skipping the clause here would lose it permanently.
 
         // Get the variables associated with the individual candidates.
         let version_set_variables = candidates
@@ -618,12 +686,37 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
         });
     }
 
-    /// Enqueues retrieving the candidates for a particular requirement. These
-    /// candidates are already filtered and sorted.
+    /// Enqueues retrieving the candidates for a particular requirement.
+    ///
+    /// For an unconditional requirement this fetches the requirement
+    /// candidates eagerly. For a conditional requirement the condition data is
+    /// fetched first; the requirement candidates are only fetched once the
+    /// encoder confirms (in [`Self::on_condition_data_available`]) that at
+    /// least one disjunct of the condition currently holds. Disjuncts that do
+    /// not yet hold are stored in
+    /// [`crate::solver::SolverState::deferred_requirements`] and encoded later
+    /// when their condition fires.
     fn queue_conditional_requirement(
         &mut self,
         solvable_id: SolvableIdOrRoot<D::SolvableId>,
         requirement: ConditionalRequirement,
+    ) {
+        match requirement.condition {
+            None => self.queue_requirement_candidates(solvable_id, requirement, None),
+            Some(condition) => self.queue_condition_data(solvable_id, requirement, condition),
+        }
+    }
+
+    /// Enqueues fetching the requirement candidates for a (possibly
+    /// pre-filtered) conditional requirement and producing a
+    /// [`TaskResult::RequirementCandidates`] task result. If `condition_data`
+    /// is `Some` the requires clauses are encoded for the provided disjuncts
+    /// only.
+    fn queue_requirement_candidates(
+        &mut self,
+        solvable_id: SolvableIdOrRoot<D::SolvableId>,
+        requirement: ConditionalRequirement,
+        condition_data: RequirementCondition<'cache, D::SolvableId>,
     ) {
         let cache = self.cache;
         self.queue_future(async move {
@@ -634,42 +727,201 @@ impl<'a, 'cache, D: DependencyProvider> Encoder<'a, 'cache, D> {
                     .map(|version_set| {
                         cache.get_or_cache_sorted_candidates_for_version_set(version_set)
                     }),
-            );
-
-            let condition_candidates = match requirement.condition {
-                Some(condition) => futures::future::try_join_all(
-                    conditions::convert_conditions_to_dnf(condition, cache.provider())
-                        .into_iter()
-                        .map(|cnf| {
-                            futures::future::try_join_all(cnf.into_iter().map(|version_set| {
-                                cache
-                                    .get_or_cache_non_matching_candidates(version_set)
-                                    .map_ok(move |matching_candidates| {
-                                        if matching_candidates.is_empty() {
-                                            DisjunctionComplement::Empty(version_set)
-                                        } else {
-                                            DisjunctionComplement::Solvables(
-                                                version_set,
-                                                matching_candidates,
-                                            )
-                                        }
-                                    })
-                            }))
-                        }),
-                )
-                .map_ok(move |dnf| Some((condition, dnf)))
-                .left_future(),
-                None => ready(Ok(None)).right_future(),
-            };
-
-            let (candidates, condition) = futures::try_join!(candidates, condition_candidates)?;
+            )
+            .await?;
 
             Ok(TaskResult::RequirementCandidates(
                 RequirementCandidatesAvailable {
                     solvable_id,
                     requirement,
                     candidates,
+                    condition: condition_data,
+                },
+            ))
+        });
+    }
+
+    /// Enqueues fetching the condition data (matching + complement candidates
+    /// per disjunct conjunct VS) for a conditional requirement. The fetch
+    /// targets only the *condition*'s packages; the requirement's candidates
+    /// are not fetched at this point, which is the entire purpose of the lazy
+    /// path.
+    fn queue_condition_data(
+        &mut self,
+        solvable_id: SolvableIdOrRoot<D::SolvableId>,
+        requirement: ConditionalRequirement,
+        condition: ConditionId,
+    ) {
+        let cache = self.cache;
+        self.queue_future(async move {
+            let dnf = conditions::convert_conditions_to_dnf(condition, cache.provider());
+            let disjuncts = futures::future::try_join_all(dnf.into_iter().map(|cnf| {
+                futures::future::try_join_all(cnf.into_iter().map(|version_set| async move {
+                    let (matching, non_matching) = futures::try_join!(
+                        cache.get_or_cache_matching_candidates(version_set),
+                        cache.get_or_cache_non_matching_candidates(version_set),
+                    )?;
+                    let complement = if non_matching.is_empty() {
+                        DisjunctionComplement::Empty(version_set)
+                    } else {
+                        DisjunctionComplement::Solvables(version_set, non_matching)
+                    };
+                    Ok::<_, Box<dyn Any>>(ConjunctData {
+                        matching,
+                        complement,
+                    })
+                }))
+                .map_ok(|conjuncts| DisjunctData { conjuncts })
+            }))
+            .await?;
+
+            Ok(TaskResult::ConditionData(ConditionDataAvailable {
+                solvable_id,
+                requirement,
+                condition,
+                disjuncts,
+            }))
+        });
+    }
+
+    /// Called when the condition data for a conditional requirement has been
+    /// resolved. Decides which disjuncts of the condition currently hold; for
+    /// each holding disjunct the encoder will fetch the requirement
+    /// candidates and emit the requires clause eagerly, and for each
+    /// non-holding disjunct an entry is pushed onto
+    /// [`crate::solver::SolverState::deferred_requirements`].
+    fn on_condition_data_available(
+        &mut self,
+        ConditionDataAvailable {
+            solvable_id,
+            requirement,
+            condition,
+            disjuncts,
+        }: ConditionDataAvailable<'cache, D::SolvableId>,
+    ) {
+        tracing::trace!(
+            "condition data available for {} (condition: {:?})",
+            requirement.requirement.display(self.cache.provider()),
+            condition,
+        );
+
+        // Partition disjuncts into "firing now" (encode eagerly) and "deferred"
+        // (push onto the deferred map).
+        let mut fired: Vec<Vec<DisjunctionComplement<'cache, D::SolvableId>>> = Vec::new();
+        let mut deferred_entries: Vec<DeferredRequirement<D::SolvableId>> = Vec::new();
+        for disjunct in disjuncts {
+            let holds = disjunct.conjuncts.iter().all(|conjunct| {
+                conjunct
+                    .matching
+                    .iter()
+                    .any(|&s| self.state.is_positively_decided(s))
+            });
+
+            if holds {
+                fired.push(
+                    disjunct
+                        .conjuncts
+                        .into_iter()
+                        .map(|c| c.complement)
+                        .collect(),
+                );
+            } else {
+                let deferred_disjunct = disjunct
+                    .conjuncts
+                    .iter()
+                    .map(|conjunct| match conjunct.complement {
+                        DisjunctionComplement::Solvables(version_set, _) => {
+                            DeferredConjunct::Solvables {
+                                version_set,
+                                matching: conjunct.matching.to_vec(),
+                            }
+                        }
+                        DisjunctionComplement::Empty(version_set) => DeferredConjunct::Empty {
+                            version_set,
+                            all_candidates: conjunct.matching.to_vec(),
+                        },
+                    })
+                    .collect();
+                deferred_entries.push(DeferredRequirement {
+                    solvable_id,
+                    requirement,
                     condition,
+                    disjunct: deferred_disjunct,
+                });
+            }
+        }
+
+        for entry in deferred_entries {
+            self.state.push_deferred(entry);
+        }
+
+        if !fired.is_empty() {
+            // The requirement is now being encoded; make sure its referenced
+            // packages have their candidates available so that locked /
+            // excluded clauses are emitted as on the eager path.
+            for version_set in requirement.requirement.version_sets(self.cache.provider()) {
+                let package_name = self.cache.provider().version_set_name(version_set);
+                self.queue_package(package_name);
+            }
+            self.queue_requirement_candidates(solvable_id, requirement, Some((condition, fired)));
+        }
+    }
+
+    /// Enqueues the future that fetches requirement candidates for a deferred
+    /// requirement and emits a single requires clause for the disjunct that
+    /// just fired. Used during the solver loop's drain step.
+    fn queue_deferred_requirement(&mut self, deferred: DeferredRequirement<D::SolvableId>) {
+        let DeferredRequirement {
+            solvable_id,
+            requirement,
+            condition,
+            disjunct,
+        } = deferred;
+        let cache = self.cache;
+
+        // The requirement is now being encoded; make sure its referenced
+        // packages have their candidates available so that locked / excluded
+        // clauses are emitted as on the eager path.
+        for version_set in requirement.requirement.version_sets(cache.provider()) {
+            let package_name = cache.provider().version_set_name(version_set);
+            self.queue_package(package_name);
+        }
+
+        self.queue_future(async move {
+            // Re-fetch the complement candidates for each conjunct of the
+            // disjunct. These are cache hits because they were fetched when
+            // the requirement was first deferred.
+            let condition_data =
+                futures::future::try_join_all(disjunct.into_iter().map(|conjunct| async move {
+                    let version_set = conjunct.version_set();
+                    let non_matching = cache
+                        .get_or_cache_non_matching_candidates(version_set)
+                        .await?;
+                    let complement = if non_matching.is_empty() {
+                        DisjunctionComplement::Empty(version_set)
+                    } else {
+                        DisjunctionComplement::Solvables(version_set, non_matching)
+                    };
+                    Ok::<_, Box<dyn Any>>(complement)
+                }))
+                .await?;
+
+            let candidates = futures::future::try_join_all(
+                requirement
+                    .requirement
+                    .version_sets(cache.provider())
+                    .map(|version_set| {
+                        cache.get_or_cache_sorted_candidates_for_version_set(version_set)
+                    }),
+            )
+            .await?;
+
+            Ok(TaskResult::RequirementCandidates(
+                RequirementCandidatesAvailable {
+                    solvable_id,
+                    requirement,
+                    candidates,
+                    condition: Some((condition, vec![condition_data])),
                 },
             ))
         });

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, fmt::Display, ops::ControlFlow};
+use std::{any::Any, fmt::Display};
 
 use ahash::{HashMap, HashSet};
 pub use cache::SolverCache;
@@ -7,7 +7,6 @@ use conditions::{Disjunction, DisjunctionId};
 use decision::Decision;
 use decision_tracker::DecisionTracker;
 use encoding::Encoder;
-use indexmap::IndexMap;
 use itertools::Itertools;
 use variable_map::VariableMap;
 
@@ -33,6 +32,7 @@ mod binary_encoding;
 mod cache;
 pub(crate) mod clause;
 mod conditions;
+mod decide_queue;
 mod decision;
 mod decision_map;
 mod decision_tracker;
@@ -196,11 +196,8 @@ pub struct Solver<D: DependencyProvider, RT: AsyncRuntime = NowOrNeverRuntime> {
     activity_decay: f32,
 }
 
-type RequiresClause = (Requirement, Option<DisjunctionId>, ClauseId);
-
 pub(crate) struct SolverState<D: DependencyProvider> {
     pub(crate) clauses: Clauses<D::NameId>,
-    requires_clauses: IndexMap<VariableId, Vec<RequiresClause>, ahash::RandomState>,
     watches: WatchMap,
 
     /// A mapping from requirements to the variables that represent the
@@ -235,6 +232,15 @@ pub(crate) struct SolverState<D: DependencyProvider> {
     /// Activity score per package.
     name_activity: <D::NameId as SolverId>::Map<f32>,
 
+    /// The largest activity stored in `name_activity`, maintained bit-exactly
+    /// next to the bumps and decays. Used by the decision fold to stop early
+    /// when no remaining item can have a strictly higher activity.
+    max_activity: f32,
+
+    /// Incremental work queue that tracks which requires clauses are eligible
+    /// for the next decision. See [`decide_queue`].
+    decide_queue: decide_queue::DecideQueue<D>,
+
     #[cfg(feature = "diagnostics")]
     propagation_counters: PropagationCounters,
 }
@@ -243,7 +249,6 @@ impl<D: DependencyProvider> Default for SolverState<D> {
     fn default() -> Self {
         Self {
             clauses: Default::default(),
-            requires_clauses: Default::default(),
             watches: Default::default(),
             requirement_to_sorted_candidates: Default::default(),
             variable_map: Default::default(),
@@ -259,6 +264,8 @@ impl<D: DependencyProvider> Default for SolverState<D> {
             constrains_aux_vars: Default::default(),
             decision_tracker: Default::default(),
             name_activity: Default::default(),
+            max_activity: 0.0,
+            decide_queue: Default::default(),
             #[cfg(feature = "diagnostics")]
             propagation_counters: Default::default(),
         }
@@ -448,6 +455,13 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     ) -> Result<Vec<D::SolvableId>, UnsolvableOrCancelled> {
         // Re-initialize the solver state.
         self.state = SolverState::default();
+
+        // The decision fold's activity-based shortcuts are only sound when
+        // activities can never become negative and cold packages stay at
+        // exactly zero.
+        self.state
+            .decide_queue
+            .set_standard_activity_params(self.activity_add > 0.0 && self.activity_decay >= 0.0);
 
         // Construct the root dependencies from the problem
         let root_dependencies = Dependencies::Known(KnownDependencies {
@@ -844,211 +858,61 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     ///    with the least amount of possible candidates requires less
     ///    backtracking to determine unsatisfiability than a requirement with
     ///    more possible candidates.
+    ///
+    /// The selection is computed incrementally by [`decide_queue::DecideQueue`]
+    /// instead of rescanning every requires clause on every call; debug
+    /// builds verify the queue's bookkeeping invariants on every call.
     fn decide(&mut self) -> Option<(VariableId, VariableId, ClauseId)> {
-        struct PossibleDecision {
-            /// The activity of the package that is selected
-            package_activity: f32,
-
-            /// If this decision is based on a requirement that is explicitly
-            /// requested by the user.
-            is_explicit_requirement: bool,
-
-            /// The total number of possible candidates that are available for
-            /// this requirement.
-            candidate_count: u32,
-
-            /// The decision to make.
-            decision: (VariableId, VariableId, ClauseId),
-        }
-
-        let mut best_decision: Option<PossibleDecision> = None;
-        for (&solvable_id, requirements) in self.state.requires_clauses.iter() {
-            let is_explicit_requirement = solvable_id == VariableId::root();
-            if let Some(best_decision) = &best_decision {
-                // If we already have an explicit requirement, there is no need to evaluate
-                // non-explicit requirements.
-                if best_decision.is_explicit_requirement && !is_explicit_requirement {
-                    continue;
-                }
-            }
-
-            // Consider only clauses in which we have decided to install the solvable
-            if self.state.decision_tracker.assigned_value(solvable_id) != Some(true) {
-                continue;
-            }
-
-            for (deps, condition, clause_id) in requirements.iter() {
-                let mut candidate = ControlFlow::Break(());
-
-                // If the clause has a condition that is not yet satisfied we need to skip it.
-                if let Some(condition) = *condition {
-                    let literals = &self.state.disjunctions[condition].literals;
-                    if !literals.iter().all(|c| {
-                        let value = c.eval(self.state.decision_tracker.map());
-                        value == Some(false)
-                    }) {
-                        // The condition is not satisfied, skip this clause.
-                        continue;
-                    }
-                }
-
-                // Get the candidates for the individual version sets.
-                let version_set_candidates = &self.state.requirement_to_sorted_candidates[*deps];
-
-                // Iterate over all version sets in the requirement and find the first version
-                // set that we can act on, or if a single candidate (from any version set) makes
-                // the clause true.
-                //
-                // NOTE: We zip the version sets from the requirements and the variables that we
-                // previously cached. This assumes that the order of the version sets is the
-                // same in both collections.
-                for (version_set, candidates) in deps
-                    .version_sets(self.provider())
-                    .zip(version_set_candidates)
-                {
-                    // Find the first candidate that is not yet assigned a value or find the first
-                    // value that makes this clause true.
-                    candidate = candidates.iter().try_fold(
-                        match candidate {
-                            ControlFlow::Continue(x) => x,
-                            _ => None,
-                        },
-                        |first_candidate, &candidate| {
-                            let assigned_value =
-                                self.state.decision_tracker.assigned_value(candidate);
-                            ControlFlow::Continue(match assigned_value {
-                                Some(true) => {
-                                    // This candidate has already been assigned so the clause is
-                                    // already true. Skip it.
-                                    return ControlFlow::Break(());
-                                }
-                                Some(false) => {
-                                    // This candidate has already been assigned false, continue the
-                                    // search.
-                                    first_candidate
-                                }
-                                None => match first_candidate {
-                                    Some((
-                                        first_candidate,
-                                        candidate_version_set,
-                                        mut candidate_count,
-                                        package_activity,
-                                    )) => {
-                                        // We found a candidate that has not been assigned yet, but
-                                        // it is not the first candidate.
-                                        if candidate_version_set == version_set {
-                                            // Increment the candidate count if this is a candidate
-                                            // in the same version set.
-                                            candidate_count += 1u32;
-                                        }
-                                        Some((
-                                            first_candidate,
-                                            candidate_version_set,
-                                            candidate_count,
-                                            package_activity,
-                                        ))
-                                    }
-                                    None => {
-                                        // We found the first candidate that has not been assigned
-                                        // yet.
-                                        let package_activity = self
-                                            .state
-                                            .name_activity
-                                            .get(self.provider().version_set_name(version_set));
-                                        Some((candidate, version_set, 1, package_activity))
-                                    }
-                                },
-                            })
-                        },
-                    );
-
-                    // Stop searching if we found a candidate that makes the clause true.
-                    if candidate.is_break() {
-                        break;
-                    }
-                }
-
-                match candidate {
-                    ControlFlow::Break(_) => {
-                        // A candidate has been assigned true which means the clause is already
-                        // true, and we can skip it.
-                        continue;
-                    }
-                    ControlFlow::Continue(None) => {
-                        unreachable!(
-                            "when we get here it means that all candidates have been assigned false. This should not be able to happen at this point because during propagation the solvable should have been assigned false as well."
-                        )
-                    }
-                    ControlFlow::Continue(Some((
-                        candidate,
-                        _version_set_id,
-                        candidate_count,
-                        package_activity,
-                    ))) => {
-                        let decision = (candidate, solvable_id, *clause_id);
-                        best_decision = Some(match &best_decision {
-                            None => PossibleDecision {
-                                is_explicit_requirement,
-                                package_activity,
-                                candidate_count,
-                                decision,
-                            },
-                            Some(best_decision) => {
-                                // Prefer decisions on explicit requirements over non-explicit
-                                // requirements. This optimizes direct dependencies over transitive
-                                // dependencies.
-                                if best_decision.is_explicit_requirement && !is_explicit_requirement
-                                {
-                                    continue;
-                                }
-
-                                // Prefer decisions with a higher package activity score to root out
-                                // conflicts faster.
-                                if best_decision.package_activity >= package_activity {
-                                    continue;
-                                }
-
-                                if best_decision.candidate_count <= candidate_count {
-                                    continue;
-                                }
-
-                                PossibleDecision {
-                                    is_explicit_requirement,
-                                    package_activity,
-                                    candidate_count,
-                                    decision,
-                                }
-                            }
-                        })
-                    }
-                }
-            }
-        }
-
-        if let Some(PossibleDecision {
-            candidate_count,
-            package_activity,
-            decision: (candidate, _solvable_id, clause_id),
+        let provider = self.cache.provider();
+        let SolverState {
+            decide_queue,
+            decision_tracker,
+            requirement_to_sorted_candidates,
+            disjunctions,
+            name_activity,
+            max_activity,
             ..
-        }) = &best_decision
-        {
+        } = &mut self.state;
+
+        let floor = decision_tracker.take_sync_floor();
+        decide_queue.sync(
+            floor,
+            decision_tracker.assignments(),
+            decision_tracker.map(),
+        );
+        let decision = decide_queue.next_decision(
+            decision_tracker.map(),
+            requirement_to_sorted_candidates,
+            disjunctions,
+            name_activity,
+            *max_activity,
+            provider,
+        );
+
+        #[cfg(debug_assertions)]
+        decide_queue.debug_assert_invariants(
+            decision_tracker.map(),
+            requirement_to_sorted_candidates,
+            disjunctions,
+            name_activity,
+            *max_activity,
+            provider,
+        );
+
+        if let Some(decision) = &decision {
             tracing::trace!(
                 "deciding to assign {}, ({}, {} activity score, {} possible candidates)",
-                candidate.display(&self.state.variable_map, self.provider()),
-                self.state.clauses.kinds[clause_id.to_index()]
+                decision
+                    .candidate
                     .display(&self.state.variable_map, self.provider()),
-                package_activity,
-                candidate_count,
+                self.state.clauses.kinds[decision.clause_id.to_index()]
+                    .display(&self.state.variable_map, self.provider()),
+                decision.package_activity,
+                decision.candidate_count,
             );
         }
 
-        // Could not find a requirement that needs satisfying.
-        best_decision.map(
-            |PossibleDecision {
-                 decision: (candidate, required_by, via),
-                 ..
-             }| { (candidate, required_by, via) },
-        )
+        decision.map(|decision| (decision.candidate, decision.required_by, decision.clause_id))
     }
 
     /// Executes one iteration of the CDCL loop
@@ -1646,10 +1510,12 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                 .as_solvable(&self.state.variable_map)
                 .map(|s| self.provider().solvable_name(s));
             if let Some(name_id) = name_id {
-                let activity = self.state.name_activity.get(name_id);
-                self.state
-                    .name_activity
-                    .set(name_id, activity + self.activity_add);
+                let activity = self.state.name_activity.get(name_id) + self.activity_add;
+                self.state.name_activity.set(name_id, activity);
+                if activity > self.state.max_activity {
+                    self.state.max_activity = activity;
+                }
+                self.state.decide_queue.mark_name_hot(name_id);
             }
         }
 
@@ -1687,10 +1553,34 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
         self.state.name_activity.for_each_mut(|activity| {
             *activity *= self.activity_decay;
         });
+        // The same f32 multiplication applied to the identical value keeps
+        // `max_activity` bit-exact with the largest stored activity.
+        self.state.max_activity *= self.activity_decay;
     }
 }
 
 impl<D: DependencyProvider> SolverState<D> {
+    /// Registers a newly encoded requires clause with the incremental decide
+    /// queue.
+    pub(crate) fn add_requires_clause(
+        &mut self,
+        parent: VariableId,
+        requirement: Requirement,
+        condition: Option<DisjunctionId>,
+        clause_id: ClauseId,
+        names: impl IntoIterator<Item = D::NameId>,
+    ) {
+        self.decide_queue.register_clause(
+            parent,
+            requirement,
+            condition,
+            clause_id,
+            names,
+            &self.disjunctions,
+            self.decision_tracker.assigned_value(parent),
+        );
+    }
+
     /// Allocate a clause and, if it has watched literals, register them in
     /// the [`WatchMap`].
     pub(crate) fn add_clause(

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -3,18 +3,19 @@ use std::{any::Any, fmt::Display};
 use ahash::{HashMap, HashSet};
 pub use cache::SolverCache;
 use clause::{Clause, Literal, WatchedLiterals};
-use conditions::{Disjunction, DisjunctionId};
+use conditions::{DeferredRequirement, Disjunction, DisjunctionId, condition_disjunct_holds};
 use decision::Decision;
 use decision_tracker::DecisionTracker;
 use encoding::Encoder;
+use indexmap::IndexMap;
 use itertools::Itertools;
 use variable_map::VariableMap;
 
 use watch_map::WatchMap;
 
 use crate::{
-    ConditionalRequirement, DenseIndex, Dependencies, DependencyProvider, KnownDependencies,
-    Requirement, SolvableId, VariableId, VersionSetId,
+    ConditionId, ConditionalRequirement, DenseIndex, Dependencies, DependencyProvider,
+    KnownDependencies, Requirement, SolvableId, VariableId, VersionSetId,
     conflict::Conflict,
     internal::{
         arena::Arena,
@@ -241,6 +242,20 @@ pub(crate) struct SolverState<D: DependencyProvider> {
     /// for the next decision. See [`decide_queue`].
     decide_queue: decide_queue::DecideQueue<D>,
 
+    /// Conditional requirements whose condition did not hold at the moment the
+    /// encoder reached them, and whose requirement candidates have therefore
+    /// not been fetched. Keyed by `ConditionId`; each entry is a list of
+    /// per-disjunct deferred requirements that share that condition.
+    ///
+    /// Invariant: an entry remains in this map only as long as the
+    /// corresponding requires clause has *not* been encoded. The first time a
+    /// deferred entry's disjunct fires the entry is drained and the encoder
+    /// builds its requires clause exactly as the eager path would have. Once
+    /// encoded the entry is removed; condition firings later in the solve
+    /// (after backtracking or otherwise) do not re-encode it.
+    deferred_requirements:
+        IndexMap<ConditionId, Vec<DeferredRequirement<D::SolvableId>>, ahash::RandomState>,
+
     #[cfg(feature = "diagnostics")]
     propagation_counters: PropagationCounters,
 }
@@ -266,6 +281,7 @@ impl<D: DependencyProvider> Default for SolverState<D> {
             name_activity: Default::default(),
             max_activity: 0.0,
             decide_queue: Default::default(),
+            deferred_requirements: Default::default(),
             #[cfg(feature = "diagnostics")]
             propagation_counters: Default::default(),
         }
@@ -396,6 +412,13 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     /// Returns the number of clauses in the solver after solving.
     pub fn clause_count(&self) -> usize {
         self.state.clauses.kinds.len()
+    }
+
+    /// Total number of deferred per-disjunct conditional requirements still
+    /// waiting for their condition to fire. Useful to verify the "remove on
+    /// first fire" invariant of the lazy-conditional-candidates path.
+    pub fn deferred_requirements_count(&self) -> usize {
+        self.state.deferred_requirements_count()
     }
 
     /// Set the runtime of the solver to `runtime`.
@@ -678,30 +701,45 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                     .map(|d| (d.variable, d.derived_from)),
             );
 
-            if new_solvables.is_empty() {
-                // If no new literals were selected this solution is complete and we can return.
+            // Also detect deferred conditional requirements whose condition
+            // has just started to hold. These have to be encoded before we can
+            // conclude the solution is complete.
+            let fired_conditions = self.state.fired_deferred_conditions();
+
+            if new_solvables.is_empty() && fired_conditions.is_empty() {
+                // If no new literals were selected and no deferred conditions
+                // fired, this solution is complete and we can return.
                 tracing::trace!(
-                    "Level {}: No new solvables selected, solution is complete",
+                    "Level {}: No new solvables or fired conditions, solution is complete",
                     level
                 );
                 return Ok(true);
             }
 
-            tracing::debug!("==== Found newly selected solvables");
-            tracing::debug!(
-                " - {}",
-                new_solvables
-                    .iter()
-                    .copied()
-                    .format_with("\n- ", |(id, derived_from), f| f(&format_args!(
-                        "{} (derived from {})",
-                        id.display(&self.state.variable_map, self.provider()),
-                        self.state.clauses.kinds[derived_from.to_index()]
-                            .display(&self.state.variable_map, self.provider()),
-                    )))
-                    .to_string()
-            );
-            tracing::debug!("====");
+            if !new_solvables.is_empty() {
+                tracing::debug!("==== Found newly selected solvables");
+                tracing::debug!(
+                    " - {}",
+                    new_solvables
+                        .iter()
+                        .copied()
+                        .format_with("\n- ", |(id, derived_from), f| f(&format_args!(
+                            "{} (derived from {})",
+                            id.display(&self.state.variable_map, self.provider()),
+                            self.state.clauses.kinds[derived_from.to_index()]
+                                .display(&self.state.variable_map, self.provider()),
+                        )))
+                        .to_string()
+                );
+                tracing::debug!("====");
+            }
+
+            if !fired_conditions.is_empty() {
+                tracing::debug!(
+                    "==== Found {} deferred condition(s) that just fired",
+                    fired_conditions.len()
+                );
+            }
 
             solvable_ids.clear();
             solvable_ids.extend(new_solvables.iter().filter_map(|(variable, _)| {
@@ -712,11 +750,17 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                     .map(SolvableIdOrRoot::from)
             }));
 
+            // Drain the fired deferred requirements.
+            let mut deferred_to_encode = Vec::new();
+            for condition in fired_conditions {
+                deferred_to_encode.extend(self.state.drain_fired_deferred(condition));
+            }
+
             #[cfg(feature = "diagnostics")]
             let encoding_start = std::time::Instant::now();
             let conflicting_clauses = self.async_runtime.block_on(
                 Encoder::new(&mut self.state, &self.cache, root_deps, level)
-                    .encode(solvable_ids.iter().copied()),
+                    .encode_with_deferred(solvable_ids.iter().copied(), deferred_to_encode),
             )?;
             #[cfg(feature = "diagnostics")]
             {
@@ -1609,5 +1653,97 @@ impl<D: DependencyProvider> SolverState<D> {
                 None
             }
         })
+    }
+
+    /// Returns true if `solvable_id` has been assigned the value `true` in the
+    /// current decision state. A solvable that has never been interned as a
+    /// variable is treated as not decided.
+    pub(crate) fn is_positively_decided(&self, solvable_id: D::SolvableId) -> bool {
+        match self.variable_map.lookup_solvable(solvable_id) {
+            Some(variable) => self.decision_tracker.assigned_value(variable) == Some(true),
+            None => false,
+        }
+    }
+
+    /// Returns the `ConditionId`s of deferred requirements whose gating
+    /// disjunct currently holds. Entries are reported in insertion order so
+    /// that drain order is deterministic.
+    pub(crate) fn fired_deferred_conditions(&self) -> Vec<ConditionId> {
+        self.deferred_requirements
+            .iter()
+            .filter(|(_, entries)| {
+                entries.iter().any(|entry| {
+                    condition_disjunct_holds(&entry.disjunct, |s| self.is_positively_decided(s))
+                })
+            })
+            .map(|(condition, _)| *condition)
+            .collect()
+    }
+
+    /// Drain deferred requirements for `condition` whose disjunct currently
+    /// holds. Removed entries are returned. If, after draining, no entries
+    /// remain for `condition`, the key is removed from the map entirely.
+    pub(crate) fn drain_fired_deferred(
+        &mut self,
+        condition: ConditionId,
+    ) -> Vec<DeferredRequirement<D::SolvableId>> {
+        // Decide first which indices fire while only holding immutable
+        // borrows of the state, then mutate the deferred map. The two-pass
+        // structure avoids overlapping mutable and immutable borrows of
+        // `self`.
+        let fire_mask: Vec<bool> = match self.deferred_requirements.get(&condition) {
+            Some(entries) => entries
+                .iter()
+                .map(|entry| {
+                    condition_disjunct_holds(&entry.disjunct, |s| self.is_positively_decided(s))
+                })
+                .collect(),
+            None => return Vec::new(),
+        };
+
+        let entries = self
+            .deferred_requirements
+            .get_mut(&condition)
+            .expect("entries existed in the immutable phase");
+        let mut fired = Vec::new();
+        // Use `remove` instead of `swap_remove`: it preserves the relative
+        // order of the entries that stay in the deferred map, so that any
+        // subsequent drain visits them in the same order regardless of how
+        // many drains have happened before. Walk indices in reverse so each
+        // `remove` does not shift the indices we still need to inspect.
+        for (i, _) in fire_mask
+            .iter()
+            .enumerate()
+            .rev()
+            .filter(|&(_, &did_fire)| did_fire)
+        {
+            fired.push(entries.remove(i));
+        }
+
+        if entries.is_empty() {
+            self.deferred_requirements.swap_remove(&condition);
+        }
+
+        // We pushed in reverse order; restore insertion order for determinism.
+        fired.reverse();
+        fired
+    }
+
+    /// Register a new deferred requirement. Used by the encoder when it
+    /// detects that a conditional requirement's disjunct does not yet hold.
+    pub(crate) fn push_deferred(&mut self, entry: DeferredRequirement<D::SolvableId>) {
+        self.deferred_requirements
+            .entry(entry.condition)
+            .or_default()
+            .push(entry);
+    }
+
+    /// Total number of deferred per-disjunct entries still waiting for their
+    /// condition to fire.
+    pub(crate) fn deferred_requirements_count(&self) -> usize {
+        self.deferred_requirements
+            .values()
+            .map(|entries| entries.len())
+            .sum()
     }
 }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -256,6 +256,39 @@ pub(crate) struct SolverState<D: DependencyProvider> {
     deferred_requirements:
         IndexMap<ConditionId, Vec<DeferredRequirement<D::SolvableId>>, ahash::RandomState>,
 
+    /// Conflicts analyzed since the last restart (or since entry) of the
+    /// current `run_sat` call, counted per conflict that yields a learnt
+    /// clause. A level-1 conflict that proves unsolvability is reported
+    /// before this is bumped, so it never paces a restart. Compared against
+    /// [`Self::restart_limit`].
+    conflicts_since_restart: u64,
+
+    /// The number of restarts performed by the current `run_sat` call;
+    /// indexes the Luby sequence that paces [`Self::restart_limit`].
+    restarts_performed: u64,
+
+    /// The conflict count at which the next restart fires (see
+    /// [`Solver::maybe_restart`]).
+    restart_limit: u64,
+
+    /// The root install level of the current `run_sat` call
+    /// (`starting_level + 1`), the retract target of
+    /// [`Solver::restart_to_run_root`]. Everything below it is preserved
+    /// prior state (the previous solution while a soft requirement is
+    /// being decided) that a restart must never undo.
+    run_root_level: u32,
+
+    /// Restart signatures (conflict level, trail length) observed by the
+    /// current `run_sat` call, with the number of restarts fired from each;
+    /// see [`RESTART_FUTILITY_REPEATS`].
+    restart_signatures: HashMap<(u32, usize), u32>,
+
+    /// Set once the current run demonstrates restart futility (one
+    /// signature reached [`RESTART_FUTILITY_REPEATS`]): the run commits to
+    /// its search and no further restarts fire until the next `run_sat`
+    /// call.
+    restarts_suppressed: bool,
+
     #[cfg(feature = "diagnostics")]
     propagation_counters: PropagationCounters,
 }
@@ -282,10 +315,69 @@ impl<D: DependencyProvider> Default for SolverState<D> {
             max_activity: 0.0,
             decide_queue: Default::default(),
             deferred_requirements: Default::default(),
+            conflicts_since_restart: 0,
+            restarts_performed: 0,
+            restart_limit: u64::MAX,
+            run_root_level: 0,
+            restart_signatures: Default::default(),
+            restarts_suppressed: false,
             #[cfg(feature = "diagnostics")]
             propagation_counters: Default::default(),
         }
     }
+}
+
+/// Base interval, in learnt conflicts, of the Luby restart sequence: the
+/// n-th restart of a `run_sat` call fires after `luby(n) *
+/// RESTART_BASE_INTERVAL` conflicts. Classic CDCL restarts keep all learnt
+/// clauses and activity scores but abandon the current partial assignment,
+/// so a search that walked into a hopeless subtree re-descends from the run
+/// root, now pruned by the learnt clauses (and reordered where conflict
+/// activity has since shifted the candidate ranking). The value 128 is the
+/// campaign-tuned one: a 512 sensitivity check kept only half the win on
+/// the hard problems and lost ground everywhere else.
+const RESTART_BASE_INTERVAL: u64 = 128;
+
+/// A restart that keeps firing from the same state — same conflict level
+/// and same trail length — is not redirecting the search: the re-descent
+/// keeps rebuilding the same prefix, which means the run is grinding one
+/// long contiguous proof that restarts only interrupt (and, near the
+/// timeout, can prevent from ever finishing). After this many restarts
+/// from one signature the run commits: restarts are suppressed until the
+/// next `run_sat` call.
+///
+/// `(level, trail length)` is a deliberately coarse fingerprint of the
+/// search state, not an identity: two genuinely different assignments can
+/// share it, so the gate can in principle over-suppress a productive run
+/// that revisits one length four times. It is chosen over the standard
+/// trail-size moving average of Glucose-style blocking restarts (Audemard
+/// & Simon) or Biere's flip-rate agility because resolvo cannot phase-save
+/// — candidate values are fixed by version preference, so a cycle here is
+/// *exact* rather than approximate, and exact-equality counting detects it
+/// without a noisy statistic. Measured on the conda-forge corpus the
+/// separation was clean: cycling runs repeated one signature dozens of
+/// times before the deadline, while the traced productive solves never
+/// repeated one (their restart states differed by tens of thousands of
+/// trail entries). 4 sits in that gap — high enough not to clip a run that
+/// briefly revisits a state, low enough to cut a cycle long before the cap.
+const RESTART_FUTILITY_REPEATS: u32 = 4;
+
+/// The Luby sequence (1, 1, 2, 1, 1, 2, 4, 1, ...) for `x >= 0`, the
+/// textbook universally-optimal restart pacing: frequent short intervals
+/// with geometrically rarer long ones, so neither short- nor long-tailed
+/// conflict distributions degenerate.
+fn luby(mut x: u64) -> u64 {
+    let (mut size, mut seq) = (1u64, 0u32);
+    while size < x + 1 {
+        seq += 1;
+        size = 2 * size + 1;
+    }
+    while size - 1 != x {
+        size = (size - 1) >> 1;
+        seq -= 1;
+        x %= size;
+    }
+    1u64 << seq
 }
 
 /// Counters that track propagation loop behavior for performance analysis.
@@ -307,6 +399,11 @@ pub(crate) struct PropagationCounters {
     pub unwatched_calls_by_type: PropagationVisitsByType,
     pub propagate_calls: u64,
     pub conflicts: u64,
+    /// Times the Luby restart policy fired (see [`Solver::maybe_restart`]).
+    pub restarts: u64,
+    /// Times a run suppressed its restarts after demonstrating futility
+    /// (see [`RESTART_FUTILITY_REPEATS`]).
+    pub restart_suppressions: u64,
     /// Time spent adding clauses from the dependency provider.
     pub encoding_duration: std::time::Duration,
     pub propagation_duration: std::time::Duration,
@@ -419,6 +516,19 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
     /// first fire" invariant of the lazy-conditional-candidates path.
     pub fn deferred_requirements_count(&self) -> usize {
         self.state.deferred_requirements_count()
+    }
+
+    /// The number of times the Luby restart policy fired.
+    #[cfg(feature = "diagnostics")]
+    pub fn restart_count(&self) -> u64 {
+        self.state.propagation_counters.restarts
+    }
+
+    /// The number of `run_sat` calls that suppressed their restarts after
+    /// hitting the futility gate.
+    #[cfg(feature = "diagnostics")]
+    pub fn restart_suppression_count(&self) -> u64 {
+        self.state.propagation_counters.restart_suppressions
     }
 
     /// Set the runtime of the solver to `runtime`.
@@ -569,6 +679,18 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
             .next_back()
             .map(|decision| self.state.decision_tracker.level(decision.variable))
             .unwrap_or(0);
+
+        // Arm the restart policy for this run: the root level pins everything
+        // the caller wants preserved (see [`SolverState::run_root_level`]),
+        // and the Luby sequence restarts from its first interval. Each
+        // `run_sat` call is its own search episode; knowledge transfers
+        // through the learnt clauses and activity scores, not the pacing.
+        self.state.run_root_level = starting_level + 1;
+        self.state.conflicts_since_restart = 0;
+        self.state.restarts_performed = 0;
+        self.state.restart_limit = RESTART_BASE_INTERVAL * luby(0);
+        self.state.restart_signatures.clear();
+        self.state.restarts_suppressed = false;
 
         let mut level = starting_level;
         let mut new_solvables: Vec<(VariableId, ClauseId)> = Vec::new();
@@ -1010,6 +1132,7 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
                         attempted_value,
                         conflicting_clause,
                     )?;
+                    level = self.maybe_restart(level);
                 }
             }
         }
@@ -1079,6 +1202,7 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
 
         let (new_level, learned_clause_id, literal) =
             self.analyze(level, conflicting_solvable, conflicting_clause);
+        self.state.conflicts_since_restart += 1;
         let old_level = level;
         level = new_level;
 
@@ -1107,6 +1231,91 @@ impl<D: DependencyProvider, RT: AsyncRuntime> Solver<D, RT> {
         }
 
         Ok(level)
+    }
+
+    /// Fires a classic CDCL restart when the current `run_sat` call has
+    /// accumulated enough conflicts since the previous one (Luby pacing,
+    /// see [`RESTART_BASE_INTERVAL`]).
+    ///
+    /// A restart undoes every decision above the run's root install level
+    /// while keeping all learnt clauses and activity scores: the search
+    /// re-descends guided by what the conflicts taught it instead of
+    /// staying committed to early decisions that predate that knowledge.
+    /// See [`Solver::restart_to_run_root`] for the retract primitive and
+    /// its soundness argument, and [`RESTART_FUTILITY_REPEATS`] for the
+    /// futility gate that makes a cycling run commit instead.
+    ///
+    /// Called only after [`Solver::learn_from_conflict`] has had its chance
+    /// to declare the problem unsolvable (a level-1 conflict returns before
+    /// we get here), so a refutation that bottoms out at the run root is
+    /// never mistaken for a restart opportunity.
+    fn maybe_restart(&mut self, level: u32) -> u32 {
+        // The count comparison is the hot-path check: on a run that never
+        // restarts it is the operand that returns, so test it first and
+        // consult the suppression flag only once a restart could fire.
+        if self.state.conflicts_since_restart < self.state.restart_limit
+            || self.state.restarts_suppressed
+        {
+            return level;
+        }
+
+        let signature = (level, self.state.decision_tracker.assignments().len());
+        let fired = self
+            .state
+            .restart_signatures
+            .entry(signature)
+            .or_insert(0u32);
+        *fired += 1;
+        if *fired >= RESTART_FUTILITY_REPEATS {
+            tracing::debug!(
+                "├─ Suppressing restarts: {} fired from level {level} with trail length {}",
+                *fired,
+                signature.1
+            );
+            self.state.restarts_suppressed = true;
+            #[cfg(feature = "diagnostics")]
+            {
+                self.state.propagation_counters.restart_suppressions += 1;
+            }
+            return level;
+        }
+
+        self.state.conflicts_since_restart = 0;
+        self.state.restarts_performed += 1;
+        self.state.restart_limit = RESTART_BASE_INTERVAL * luby(self.state.restarts_performed);
+        #[cfg(feature = "diagnostics")]
+        {
+            self.state.propagation_counters.restarts += 1;
+        }
+
+        if level > self.state.run_root_level {
+            tracing::debug!(
+                "├─ Restart {}: backtracking from level {level} to {}",
+                self.state.restarts_performed,
+                self.state.run_root_level
+            );
+        }
+        self.restart_to_run_root(level)
+    }
+
+    /// The restart primitive: retracts the trail to
+    /// [`SolverState::run_root_level`], the root install level of the
+    /// current run. Kept separate from [`Solver::maybe_restart`] so other
+    /// restart triggers can share one retract path.
+    ///
+    /// Everything below the root level (a preserved prior solution while a
+    /// soft requirement is being decided) survives by construction. Learnt
+    /// clauses and activity scores are untouched. Backtracking is the only
+    /// effect; assertions of single-literal learnt clauses are re-applied
+    /// by [`Solver::decide_learned`] on the next propagation round.
+    fn restart_to_run_root(&mut self, level: u32) -> u32 {
+        let root_level = self.state.run_root_level;
+        if level <= root_level {
+            // Already at (or below) the restart target.
+            return level;
+        }
+        self.state.decision_tracker.undo_until(root_level);
+        root_level
     }
 
     /// The propagate step of the CDCL algorithm
@@ -1745,5 +1954,16 @@ impl<D: DependencyProvider> SolverState<D> {
             .values()
             .map(|entries| entries.len())
             .sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::luby;
+
+    #[test]
+    fn luby_produces_the_textbook_sequence() {
+        let observed: Vec<u64> = (0..15).map(luby).collect();
+        assert_eq!(observed, vec![1, 1, 2, 1, 1, 2, 4, 1, 1, 2, 1, 1, 2, 4, 8]);
     }
 }

--- a/src/solver/variable_map.rs
+++ b/src/solver/variable_map.rs
@@ -82,6 +82,13 @@ impl<N: SolverId, S: SolverId> VariableMap<N, S> {
         variable_id
     }
 
+    /// Looks up the variable for a solvable without allocating one. Returns
+    /// `None` if no variable has been allocated for this solvable yet, which
+    /// implies the solvable has not been decided.
+    pub fn lookup_solvable(&self, solvable_id: S) -> Option<VariableId> {
+        self.solvable_to_variable.get(solvable_id)
+    }
+
     #[cfg(feature = "diagnostics")]
     pub fn count(&self) -> usize {
         self.origins.len()

--- a/src/solver_id.rs
+++ b/src/solver_id.rs
@@ -215,6 +215,9 @@ pub trait IdMap<K, V: Copy + Default> {
     /// Dense maps visit every allocated slot. Sparse maps visit only entries
     /// that were explicitly written.
     fn for_each_mut(&mut self, visit: impl FnMut(&mut V));
+
+    /// Immutable variant of [`Self::for_each_mut`].
+    fn for_each(&self, visit: impl FnMut(&V));
 }
 
 /// A set keyed by solver IDs.
@@ -255,6 +258,10 @@ impl<K: DenseIndex, V: Copy + Default> IdMap<K, V> for Vec<V> {
     fn for_each_mut(&mut self, visit: impl FnMut(&mut V)) {
         self.iter_mut().for_each(visit);
     }
+
+    fn for_each(&self, visit: impl FnMut(&V)) {
+        self.iter().for_each(visit);
+    }
 }
 
 impl<K: DenseIndex> IdSet<K> for IndexedSet<K> {
@@ -279,6 +286,10 @@ impl<K: Eq + Hash, V: Copy + Default, S: BuildHasher> IdMap<K, V> for HashMap<K,
 
     fn for_each_mut(&mut self, visit: impl FnMut(&mut V)) {
         HashMap::values_mut(self).for_each(visit);
+    }
+
+    fn for_each(&self, visit: impl FnMut(&V)) {
+        HashMap::values(self).for_each(visit);
     }
 }
 

--- a/src/utils/mapping.rs
+++ b/src/utils/mapping.rs
@@ -76,6 +76,25 @@ impl<TId: DenseIndex, TValue> Mapping<TId, TValue> {
         previous_value
     }
 
+    /// Returns a mutable reference to the value for `id`, inserting the
+    /// result of `default` first if the slot is empty. Performs the chunk
+    /// addressing only once, unlike a `get`/`insert`/`get_mut` sequence.
+    pub fn get_or_insert_with(&mut self, id: TId, default: impl FnOnce() -> TValue) -> &mut TValue {
+        let idx = id.to_index();
+        let (chunk, offset) = Self::chunk_and_offset(idx);
+        if chunk >= self.chunks.len() {
+            self.chunks
+                .resize_with(chunk + 1, || std::array::from_fn(|_| None));
+        }
+        let slot = &mut self.chunks[chunk][offset];
+        if slot.is_none() {
+            *slot = Some(default());
+            self.len += 1;
+            self.max = self.max.max(idx);
+        }
+        slot.as_mut().expect("slot was just filled")
+    }
+
     /// Unset a specific value in the mapping, returns the previous value.
     pub fn unset(&mut self, id: TId) -> Option<TValue> {
         let idx = id.to_index();

--- a/tests/solver/bundle_box/mod.rs
+++ b/tests/solver/bundle_box/mod.rs
@@ -40,8 +40,8 @@ use itertools::Itertools;
 pub use pack::Pack;
 use resolvo::{
     Candidates, Condition, ConditionId, ConditionalRequirement, Dependencies, DependencyProvider,
-    Interner, KnownDependencies, NameId, SolvableId, SolverCache, StringId, VersionSetId,
-    VersionSetUnionId, snapshot::DependencySnapshot, utils::Pool,
+    HintDependenciesAvailable, Interner, KnownDependencies, NameId, SolvableId, SolverCache,
+    StringId, VersionSetId, VersionSetUnionId, snapshot::DependencySnapshot, utils::Pool,
 };
 pub use spec::Spec;
 use version_ranges::Ranges;
@@ -61,6 +61,11 @@ pub struct BundleBoxProvider {
     concurrent_requests: Arc<AtomicUsize>,
     pub concurrent_requests_max: Rc<Cell<usize>>,
     pub sleep_before_return: bool,
+    /// When set, candidates are returned with
+    /// [`HintDependenciesAvailable::All`], which makes the solver prefetch
+    /// (and encode) the dependencies of requirement candidates as soon as the
+    /// requirement itself is encoded.
+    pub hint_dependencies_available: bool,
 
     // A mapping of packages that we have requested candidates for. This way we can keep track of
     // duplicate requests.
@@ -233,6 +238,17 @@ impl BundleBoxProvider {
     pub fn solvable_id(&self, name: impl Into<String>, version: impl Into<Pack>) -> SolvableId {
         self.intern_solvable(self.pool.intern_package_name(name.into()), version.into())
     }
+
+    /// Returns the package names for which the solver has issued a
+    /// `get_candidates` request. Used by tests that verify lazy candidate
+    /// loading does not fetch unreachable packages.
+    pub fn requested_package_names(&self) -> Vec<String> {
+        self.requested_candidates
+            .borrow()
+            .iter()
+            .map(|id| self.pool.resolve_package_name(*id).to_string())
+            .collect()
+    }
 }
 
 impl Interner for BundleBoxProvider {
@@ -343,6 +359,11 @@ impl DependencyProvider for BundleBoxProvider {
 
         let mut candidates = Candidates {
             candidates: Vec::with_capacity(package.len()),
+            hint_dependencies_available: if self.hint_dependencies_available {
+                HintDependenciesAvailable::All
+            } else {
+                HintDependenciesAvailable::None
+            },
             ..Candidates::default()
         };
         let favor = self.favored.get(package_name);

--- a/tests/solver/decide_queue_prop.rs
+++ b/tests/solver/decide_queue_prop.rs
@@ -1,0 +1,78 @@
+//! Random dependency graphs (cycles allowed): in debug builds every decide()
+//! call verifies the decide queue's bookkeeping invariants, so this property
+//! test checks the queue's wake-up machinery across arbitrary search shapes.
+
+use super::*;
+use proptest::prelude::*;
+
+type Dep = (usize, u32, u32);
+
+#[derive(Debug, Clone)]
+struct RandomProblem {
+    /// packages[i] = versions; each version body = (deps, constrains).
+    packages: Vec<Vec<(Vec<Dep>, Vec<Dep>)>>,
+    roots: Vec<Dep>,
+}
+
+fn spec(n_packages: usize) -> impl Strategy<Value = Dep> {
+    (0..n_packages, 0u32..5, 1u32..4)
+}
+
+fn random_problem() -> impl Strategy<Value = RandomProblem> {
+    (2usize..10).prop_flat_map(|n| {
+        let version_body = (
+            prop::collection::vec(spec(n), 0..=3),
+            prop::collection::vec(spec(n), 0..=1),
+        );
+        (
+            prop::collection::vec(prop::collection::vec(version_body, 1..=3), n),
+            prop::collection::vec(spec(n), 1..=3),
+        )
+            .prop_map(|(packages, roots)| RandomProblem { packages, roots })
+    })
+}
+
+fn to_spec_strings(deps: &[Dep]) -> Vec<String> {
+    deps.iter()
+        .map(|&(pkg, lo, len)| format!("p{pkg} {lo}..{}", lo + len))
+        .collect()
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+    #[test]
+    fn decide_queue_matches_reference_on_random_problems(problem in random_problem()) {
+        let n = problem.packages.len();
+        let mut provider = BundleBoxProvider::new();
+        for (pkg, versions) in problem.packages.iter().enumerate() {
+            for (version, (deps, constrains)) in versions.iter().enumerate() {
+                let deps = to_spec_strings(deps);
+                let deps: Vec<&str> = deps.iter().map(String::as_str).collect();
+                // A package constraining its own name trips a pre-existing
+                // debug assertion (Constrains(A, A) yields two identical
+                // watch literals); redirect those until that is fixed.
+                let constrains: Vec<Dep> = constrains
+                    .iter()
+                    .map(|&(target, lo, len)| {
+                        (if target == pkg { (target + 1) % n } else { target }, lo, len)
+                    })
+                    .collect();
+                let constrains = to_spec_strings(&constrains);
+                let constrains: Vec<&str> = constrains.iter().map(String::as_str).collect();
+                provider.add_package(
+                    &format!("p{pkg}"),
+                    (version as u32 + 1).into(),
+                    &deps,
+                    &constrains,
+                );
+            }
+        }
+
+        let roots = to_spec_strings(&problem.roots);
+        let roots: Vec<&str> = roots.iter().map(String::as_str).collect();
+        let requirements = provider.requirements(&roots);
+
+        let mut solver = Solver::new(provider);
+        let _ = solver.solve(Problem::new().requirements(requirements));
+    }
+}

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -1490,3 +1490,110 @@ fn test_constrains_multiple_parents() {
     x=1
     "###);
 }
+
+// ============================================================================
+// Decide-queue wake-up scenarios
+// ============================================================================
+// Each test targets a wake-up path of `solver::decide_queue`. In debug builds
+// every decide() call verifies the queue's bookkeeping invariants, so these
+// tests check the queue throughout the search, not just the solution.
+
+/// Satisfied-watch break and re-satisfaction: a=2 satisfies its `x 2..3`
+/// requirement with x=2, the conflict with b's `x 1..2` undoes that, and
+/// after backtracking the requires clauses must become eligible again
+/// (parent re-wake) and be satisfiable by x=1. The conflict also bumps x,
+/// promoting queued items to the hot queue.
+#[test]
+fn test_decide_queue_satisfaction_break() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("x", 1.into(), &[], &[]);
+    provider.add_package("x", 2.into(), &[], &[]);
+    provider.add_package("a", 1.into(), &["x 1..2"], &[]);
+    provider.add_package("a", 2.into(), &["x 2..3"], &[]);
+    provider.add_package("b", 1.into(), &["x 1..2"], &[]);
+
+    let requirements = provider.requirements(&["a", "b"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    a=1
+    b=1
+    x=1
+    "###);
+}
+
+/// Backjump past a parent: mid=2 is undone by the conflict between its
+/// `leaf 2..3` requirement and root's explicit `leaf 1..2`, so mid's queued
+/// items become ineligible and mid=1's items must be woken afterwards.
+#[test]
+fn test_decide_queue_backjump_past_parent() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("leaf", 1.into(), &[], &[]);
+    provider.add_package("leaf", 2.into(), &[], &[]);
+    provider.add_package("mid", 1.into(), &["leaf 1..2"], &[]);
+    provider.add_package("mid", 2.into(), &["leaf 2..3"], &[]);
+    provider.add_package("top", 1.into(), &["mid"], &[]);
+
+    let requirements = provider.requirements(&["top", "leaf 1..2"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    leaf=1
+    mid=1
+    top=1
+    "###);
+}
+
+/// Condition wake-up in both polarities: the condition on `baz; if bar 2..3`
+/// completes and breaks as bar flips between 2 and 1 during the conflict
+/// with qux's `bar 1..2` requirement.
+#[test]
+fn test_decide_queue_condition_toggles() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("bar", 1.into(), &[], &[]);
+    provider.add_package("bar", 2.into(), &[], &[]);
+    provider.add_package("baz", 1.into(), &[], &[]);
+    provider.add_package("foo", 1.into(), &["baz; if bar 2..3"], &[]);
+    provider.add_package("qux", 1.into(), &["bar 1..2"], &[]);
+
+    let requirements = provider.requirements(&["foo", "bar", "qux"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    bar=1
+    foo=1
+    qux=1
+    "###);
+}
+
+/// Mid-solve reset: b=2's constraint on a is encoded only after a=1 is
+/// already installed, which reports a conflicting clause, resets the search
+/// to level 0 (clearing the decision tracker), and restarts. The queue's
+/// trail mirror must survive the reset.
+#[test]
+fn test_decide_queue_reset_on_late_conflict() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("a", 1.into(), &[], &[]);
+    provider.add_package("b", 1.into(), &[], &[]);
+    provider.add_package("b", 2.into(), &[], &["a 2..3"]);
+
+    let requirements = provider.requirements(&["a", "b"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    a=1
+    b=1
+    "###);
+}
+
+/// Union requirement naming the same package in several version sets: the
+/// queue's name occurrence lists deduplicate the item registration.
+#[test]
+fn test_decide_queue_union_duplicate_name() {
+    let mut provider = BundleBoxProvider::new();
+    provider.add_package("x", 1.into(), &[], &[]);
+    provider.add_package("x", 3.into(), &[], &[]);
+    provider.add_package("a", 1.into(), &["x 0..2 | x 3..4"], &[]);
+    provider.add_package("b", 1.into(), &["x 0..2"], &[]);
+
+    let requirements = provider.requirements(&["a", "b"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    a=1
+    b=1
+    x=1
+    "###);
+}
+
+mod decide_queue_prop;

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -859,6 +859,34 @@ fn test_snapshot() {
     assert_snapshot!(solve_for_snapshot(snapshot_provider, &[menu_req], &[]));
 }
 
+/// The snapshot's *highest-index* version set must remain resolvable through a
+/// [`resolvo::snapshot::SnapshotProvider`]. The provider used to route any
+/// index `>= Mapping::max()` to the additional version sets added via
+/// `add_package_requirement`, but `max()` is the highest inserted index (not a
+/// count), so the snapshot's last version set was shadowed by the first
+/// additional one, panicking with an out-of-bounds index when no additional
+/// set existed, and silently resolving to the wrong version set otherwise.
+#[test]
+fn test_snapshot_highest_version_set_not_shadowed() {
+    let provider = BundleBoxProvider::from_packages(&[("a", 1, vec!["b 1"]), ("b", 1, vec![])]);
+
+    let a_name_id = provider.package_name("a");
+    let snapshot = provider.into_snapshot();
+
+    let mut snapshot_provider = snapshot.provider();
+    let a_req = snapshot_provider
+        .add_package_requirement(a_name_id, "*")
+        .into();
+
+    // Solving must resolve `b 1`, the highest-index version set in the
+    // snapshot, to pull in `b`. With the shadowing bug the lookup either
+    // panicked or resolved to the additional `a *` set, dropping `b`.
+    assert_snapshot!(solve_for_snapshot(snapshot_provider, &[a_req], &[]), @r###"
+    a=1
+    b=1
+    "###);
+}
+
 #[test]
 fn test_snapshot_union_requirements() {
     let mut provider = BundleBoxProvider::from_packages(&[
@@ -1076,6 +1104,597 @@ fn test_condition_missing_requirement() {
 
     let requirements = provider.requirements(&["menu"]);
     assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @"menu=1");
+}
+
+// ---------------------------------------------------------------------------
+// Lazy conditional candidate loading
+// ---------------------------------------------------------------------------
+//
+// The tests below cover the edge cases of the lazy-conditional-candidates
+// mechanism: deferred requirements should only fetch the gated packages once
+// the condition actually fires, multi-disjunct conditions should fire
+// per-disjunct, deferral must survive backtracking, etc.
+
+/// The conditional requirement's "if C" gate never fires, so the gated package
+/// `bla` (and its dependency `dep`) should never have its candidates fetched.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_skips_unreached_candidates() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if bar"]),
+        ("bla", 1, vec!["dep"]),
+        ("dep", 1, vec![]),
+        ("bar", 1, vec![]),
+    ]);
+
+    // We do *not* require `bar`, so the condition `if bar` never fires.
+    let requirements = provider.requirements(&["foo"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @"foo=1");
+
+    let fetched = solver.provider().requested_package_names();
+    assert!(
+        !fetched.iter().any(|name| name == "bla"),
+        "expected `bla` to remain unfetched, got {fetched:?}"
+    );
+    assert!(
+        !fetched.iter().any(|name| name == "dep"),
+        "expected `dep` to remain unfetched, got {fetched:?}"
+    );
+}
+
+/// When the condition fires the deferred clause is encoded and the gated
+/// package is fetched. Sanity check that the eager observable behaviour still
+/// produces the right solution.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_fires_when_condition_holds() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if bar"]),
+        ("bla", 1, vec![]),
+        ("bar", 1, vec![]),
+    ]);
+
+    let requirements = provider.requirements(&["foo", "bar"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    bar=1
+    bla=1
+    foo=1
+    "###);
+}
+
+/// `a OR b` is a multi-disjunct condition. Firing only `a` should still
+/// produce a correct solution: the `a`-disjunct's clause is encoded when `a`
+/// is selected, and the `b`-disjunct stays deferred (and is never needed).
+#[test]
+#[traced_test]
+fn test_lazy_conditional_multi_disjunct_fires_per_disjunct() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if a or b"]),
+        ("bla", 1, vec![]),
+        ("a", 1, vec![]),
+        ("b", 1, vec![]),
+    ]);
+
+    // Only require `a`, not `b`. The disjunct gated on `a` must fire so that
+    // `bla` is included.
+    let requirements = provider.requirements(&["foo", "a"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    a=1
+    bla=1
+    foo=1
+    "###);
+}
+
+/// Multiple `requires ... if C` for the same condition should all be encoded
+/// when `C` fires. This exercises the "Multiple conditional requirements share
+/// the same `ConditionId`" edge case.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_shared_condition_fires_all() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if cond", "ext; if cond"]),
+        ("bla", 1, vec![]),
+        ("ext", 1, vec![]),
+        ("cond", 1, vec![]),
+    ]);
+
+    let requirements = provider.requirements(&["foo", "cond"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    bla=1
+    cond=1
+    ext=1
+    foo=1
+    "###);
+}
+
+/// When the condition fires *and* the requirement is unsolvable, the solver
+/// must report the conflict, not panic and not loop forever.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_late_arriving_conflict_is_reported() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla 2; if bar"]),
+        ("bar", 1, vec![]),
+        ("bla", 1, vec![]),
+    ]);
+
+    // The condition `if bar` will fire because we require `bar`; the gated
+    // requirement asks for `bla 2` but only `bla 1` exists, so the resolution
+    // is unsolvable.
+    let requirements = provider.requirements(&["foo", "bar"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    foo * cannot be installed because there are no viable options:
+    └─ foo 1 would require
+       └─ bla >=2, <3, for which no candidates were found.
+    The following packages are incompatible
+    └─ bar * can be installed with any of the following options:
+       └─ bar 1
+    "###);
+}
+
+/// Force backtracking through a deferred conditional requirement: `b 1` forces
+/// `cond`, which fires the deferred `bla; if cond`. Then the solver finds a
+/// conflict on `bla 2` and must backtrack. After backtracking it picks `b 2`
+/// (which does not force `cond`), and the deferred clause is *already*
+/// encoded (clauses are not unlearnt). The solver must still find a solution
+/// and must not encode the deferred clause twice.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_survives_backtracking() {
+    // Force the solver down a path that fires the deferred condition and
+    // then backtracks:
+    //
+    // - root requires `foo` and `cond`. `cond` is required unconditionally
+    //   so the condition `if cond` is guaranteed to fire.
+    // - `foo` has two versions; the higher (`foo=2`) carries `bla 2`
+    //   (no candidate -> conflict) in addition to the deferred `bla; if
+    //   cond`. The conflict is only discovered after the deferred clause
+    //   fires and forces a `bla` selection.
+    // - After backtracking the solver settles on `foo=1`, which only has
+    //   the deferred `bla; if cond` requirement. The deferred clause is
+    //   reused from the failed branch (CDCL does not unlearn clauses).
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 2, vec!["bla; if cond", "bla 2"]),
+        ("foo", 1, vec!["bla; if cond"]),
+        ("bla", 1, vec![]),
+        ("cond", 1, vec![]),
+    ]);
+
+    let requirements = provider.requirements(&["foo", "cond"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @r###"
+    bla=1
+    cond=1
+    foo=1
+    "###);
+
+    // The `if cond` disjunct fired (cond is required), so the deferred
+    // entry was drained. The map must be empty even though the solve went
+    // through a conflict + backtrack on `foo=2`. A future regression that
+    // accidentally re-enqueues an entry on backtrack would leave a
+    // leftover here -- this is the observable hook for the "remove on
+    // first fire" invariant.
+    assert_eq!(
+        solver.deferred_requirements_count(),
+        0,
+        "deferred entries must be drained on first fire and never re-added"
+    );
+
+    // Resolve the exact same problem on a fresh solver and record its
+    // clause count. The lazy path is deterministic, so a re-solve from
+    // scratch produces the same clauses. If the original solve's
+    // backtracking accidentally caused a double-encode of any deferred
+    // clause, its clause count would be higher than the fresh re-solve's.
+    let fresh_clauses = {
+        let mut provider = BundleBoxProvider::from_packages(&[
+            ("foo", 2, vec!["bla; if cond", "bla 2"]),
+            ("foo", 1, vec!["bla; if cond"]),
+            ("bla", 1, vec![]),
+            ("cond", 1, vec![]),
+        ]);
+        let requirements = provider.requirements(&["foo", "cond"]);
+        let mut fresh_solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let _ = fresh_solver.solve(problem).unwrap();
+        fresh_solver.clause_count()
+    };
+    assert_eq!(
+        solver.clause_count(),
+        fresh_clauses,
+        "clause count must match a fresh re-solve; a mismatch would mean a \
+         deferred entry was encoded more than once"
+    );
+}
+
+/// Regression test for the lazy-conditional prefetch path: a candidate of a
+/// deferred requirement can already be decided *false* by the time the
+/// condition fires. `c`'s constraint `gated 2..3` propagates `gated=1` to
+/// false as soon as `c` is installed. When `cond` is later installed, the
+/// deferred `gated; if cond` fires and the encoder loads the `gated`
+/// candidates, prefetching their dependencies (the provider hints that they
+/// are cheaply available). Encoding `gated=1`'s requires/constrains clauses
+/// while `gated=1` is false used to trip the
+/// `assert_ne!(.., Some(false))` in `WatchedLiterals::constrains` (pairwise
+/// encoding) and `WatchedLiterals::constrains_parent` (shared encoding). The
+/// clauses must be added rather than skipped: the false assignment can be
+/// backtracked later, and neither the drained deferred entry nor the
+/// prefetched solvable is ever revisited.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_prefetches_forbidden_candidate() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("a", 1, vec!["gated; if cond"]),
+        ("trigger", 1, vec!["cond"]),
+        ("cond", 1, vec![]),
+        ("gated", 2, vec![]),
+        ("dep", 1, vec![]),
+        ("z", 1, vec![]),
+        ("w", 1, vec![]),
+        ("w", 2, vec![]),
+        ("w", 3, vec![]),
+        ("w", 4, vec![]),
+    ]);
+    provider.hint_dependencies_available = true;
+    // Installing `c` forbids `gated=1` through a constraint.
+    provider.add_package("c", 1.into(), &[], &["gated 2..3"]);
+    // `gated=1` carries a requirement and two constraints so that the
+    // requires path and both constrains encodings run with a false parent:
+    // `z 2..3` excludes a single candidate (pairwise `Constrains`), while
+    // `w 5..6` excludes four candidates (shared `ConstrainsParent` encoding).
+    provider.add_package("gated", 1.into(), &["dep"], &["z 2..3", "w 5..6"]);
+
+    let requirements = provider.requirements(&["c", "a", "trigger"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @r###"
+    a=1
+    c=1
+    cond=1
+    gated=2
+    trigger=1
+    "###);
+}
+
+/// `condition: None` requirements must continue to behave eagerly: the gated
+/// package should be fetched even though we never decide on it. This is the
+/// existing behaviour, kept here as a regression guard.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_unconditional_unaffected() {
+    let mut provider =
+        BundleBoxProvider::from_packages(&[("foo", 1, vec!["bla"]), ("bla", 1, vec![])]);
+
+    let requirements = provider.requirements(&["foo"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @r###"
+    bla=1
+    foo=1
+    "###);
+
+    let fetched = solver.provider().requested_package_names();
+    assert!(
+        fetched.iter().any(|name| name == "bla"),
+        "unconditional requirements must still fetch their candidates; got {fetched:?}"
+    );
+}
+
+/// Empty-complement condition: `if bar` is `bar *`, whose complement is
+/// always empty (every candidate of `bar` matches `*`). The encoder relies
+/// on the at-least-one tracker for `bar` to gate the requires clause. The
+/// deferred path must agree with that semantics: the condition holds iff
+/// any candidate of `bar` is selected.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_empty_complement_fires() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("foo", 1, vec!["bla; if bar"]),
+        // Multiple versions of bar: the VS `bar *` still matches all of
+        // them, so its complement is empty.
+        ("bar", 1, vec![]),
+        ("bar", 2, vec![]),
+        ("bla", 1, vec![]),
+    ]);
+
+    // With `bar` requested, the condition fires and the deferred clause is
+    // encoded.
+    let requirements = provider.requirements(&["foo", "bar"]);
+    assert_snapshot!(solve_for_snapshot(provider, &requirements, &[]), @r###"
+    bar=2
+    bla=1
+    foo=1
+    "###);
+}
+
+/// Determinism: running the same problem ten times must produce the exact
+/// same solution. The deferred-requirement drain order must not depend on
+/// hash iteration.
+#[test]
+fn test_lazy_conditional_determinism() {
+    fn build_provider() -> BundleBoxProvider {
+        BundleBoxProvider::from_packages(&[
+            ("foo", 1, vec!["bla; if a", "ext; if b"]),
+            ("foo", 2, vec!["bla; if a", "ext; if b"]),
+            ("bla", 1, vec![]),
+            ("ext", 1, vec![]),
+            ("a", 1, vec![]),
+            ("b", 1, vec![]),
+        ])
+    }
+
+    let baseline = {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["foo", "a", "b"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        transaction_to_string(solver.provider(), &solved)
+    };
+
+    for _ in 0..9 {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["foo", "a", "b"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        assert_eq!(result, baseline, "non-deterministic solve");
+    }
+}
+
+/// Multi-conjunct (`a AND b`) condition. `convert_conditions_to_dnf`
+/// distributes AND over OR, so `cond_a AND cond_b` becomes a single disjunct
+/// with two conjuncts. The lazy path's `condition_disjunct_holds` only fires
+/// when *every* conjunct in the disjunct holds.
+///
+/// Existing tests cover only single-conjunct disjuncts (`if x` or `if x or
+/// y`), leaving the `disjunct.iter().all(...)` arm of
+/// `condition_disjunct_holds` unexercised. This test fixes that gap with
+/// three sub-cases sharing the same fixture but with different root
+/// requirements.
+mod test_lazy_conditional_multi_conjunct_requires_all {
+    use super::*;
+
+    fn build_provider() -> BundleBoxProvider {
+        BundleBoxProvider::from_packages(&[
+            ("a", 1, vec!["b; if cond_a and cond_b"]),
+            ("b", 1, vec![]),
+            ("cond_a", 1, vec![]),
+            ("cond_b", 1, vec![]),
+        ])
+    }
+
+    /// Neither conjunct fires. `b` must not be in the resolution and must
+    /// not have its candidates fetched.
+    #[test]
+    #[traced_test]
+    fn neither_selected() {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["a"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        assert_snapshot!(result, @"a=1");
+
+        let fetched = solver.provider().requested_package_names();
+        assert!(
+            !fetched.iter().any(|n| n == "b"),
+            "expected `b` to remain unfetched when neither conjunct holds, \
+             got {fetched:?}"
+        );
+        assert_eq!(
+            solver.deferred_requirements_count(),
+            1,
+            "the AND-disjunct never held, its deferred entry must remain"
+        );
+    }
+
+    /// Only the first conjunct fires. `b` must not be in the resolution and
+    /// must not have its candidates fetched: the lazy path requires *every*
+    /// conjunct of the AND-disjunct to hold.
+    #[test]
+    #[traced_test]
+    fn only_first_selected() {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["a", "cond_a"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        assert_snapshot!(result, @r###"
+        a=1
+        cond_a=1
+        "###);
+
+        let fetched = solver.provider().requested_package_names();
+        assert!(
+            !fetched.iter().any(|n| n == "b"),
+            "expected `b` to remain unfetched when only one conjunct holds, \
+             got {fetched:?}"
+        );
+        assert_eq!(
+            solver.deferred_requirements_count(),
+            1,
+            "second conjunct (cond_b) did not hold, deferred entry must remain"
+        );
+    }
+
+    /// Both conjuncts fire. `b` must be in the resolution.
+    #[test]
+    #[traced_test]
+    fn both_selected() {
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["a", "cond_a", "cond_b"]);
+        let mut solver = Solver::new(provider);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        assert_snapshot!(result, @r###"
+        a=1
+        b=1
+        cond_a=1
+        cond_b=1
+        "###);
+
+        assert_eq!(
+            solver.deferred_requirements_count(),
+            0,
+            "both conjuncts hold, the deferred entry must have been drained"
+        );
+    }
+}
+
+/// Determinism under non-deterministic async ordering. The plain
+/// [`test_lazy_conditional_determinism`] uses the default
+/// `sleep_before_return = false`, so every `get_candidates` future resolves
+/// synchronously and ordering is trivially deterministic. This test enables
+/// `sleep_before_return = true` so each provider call awaits a 10 ms timer
+/// inside the tokio runtime, forcing the `FuturesUnordered` driving the
+/// encoder to actually interleave futures.
+///
+/// We then assert that across 10 runs of the same problem:
+/// - the resolution (the solvables list) is byte-identical, and
+/// - the sorted set of packages whose candidates were fetched
+///   (`requested_package_names`) is byte-identical.
+///
+/// The second assertion is the load-bearing one for this test: it guards the
+/// deferred-requirement drain order. A regression that drains
+/// `SolverState::deferred_requirements` by hash iteration would still yield
+/// the same final resolution (CDCL is deterministic given the same input
+/// clauses) but the *order* in which conditional packages get fetched would
+/// drift, observable here as differing `requested_package_names`.
+#[test]
+fn test_lazy_conditional_determinism_async() {
+    fn build_provider() -> BundleBoxProvider {
+        let mut p = BundleBoxProvider::from_packages(&[
+            // Multiple deferred conditional requirements sharing distinct
+            // conditions, plus an inner conditional on `bla` that only
+            // fires once `a` is selected. The graph is non-trivial enough
+            // that a buggy drain order would surface.
+            ("foo", 1, vec!["bla; if a", "ext; if b", "tail; if c"]),
+            ("foo", 2, vec!["bla; if a", "ext; if b", "tail; if c"]),
+            ("bla", 1, vec!["inner; if a"]),
+            ("ext", 1, vec![]),
+            ("tail", 1, vec![]),
+            ("inner", 1, vec![]),
+            ("a", 1, vec![]),
+            ("b", 1, vec![]),
+            ("c", 1, vec![]),
+        ]);
+        // Force every provider future to await a real timer so the encoder's
+        // `FuturesUnordered` driver actually has to interleave them.
+        p.sleep_before_return = true;
+        p
+    }
+
+    fn run() -> (String, Vec<String>) {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap();
+        let mut provider = build_provider();
+        let requirements = provider.requirements(&["foo", "a", "b", "c"]);
+        let mut solver = Solver::new(provider).with_runtime(runtime);
+        let problem = Problem::new().requirements(requirements);
+        let solved = solver.solve(problem).unwrap();
+        let result = transaction_to_string(solver.provider(), &solved);
+        let mut fetched = solver.provider().requested_package_names();
+        // Sort so the assertion targets the *set* of fetched packages,
+        // which is what determinism guarantees -- the *insertion* order
+        // into the underlying HashSet is hash-randomised and not part of
+        // the solver's contract.
+        fetched.sort();
+        (result, fetched)
+    }
+
+    let baseline = run();
+    for i in 0..9 {
+        let next = run();
+        assert_eq!(
+            next.0, baseline.0,
+            "non-deterministic resolution under async ordering at iteration {i}"
+        );
+        assert_eq!(
+            next.1, baseline.1,
+            "non-deterministic fetched-packages set under async ordering at \
+             iteration {i}"
+        );
+    }
+}
+
+/// Pin the observable semantic divergence between the lazy-conditional path
+/// and the prior eager SAT encoding.
+///
+/// Setup: `cond` has versions `1` and `2`. The condition VS `cond 2..3` matches
+/// only `cond=2`; its complement is `{cond=1}`. We externally exclude `cond=1`
+/// so the *complement* is fully decided-false, while *nothing* positively
+/// selects `cond=2`. The conditional requirement is `a` requires `b` if
+/// `cond>=2`.
+///
+/// Behaviour comparison:
+/// - **Eager (legacy) path**: emits the SAT clause `¬a v ¬C!1 v b1` (where
+///   `C!1` is the complement candidate `cond=1`). With `cond=1` excluded
+///   (decided false), `¬C!1` is satisfied, so the clause forces `b1`. `b`
+///   would appear in the resolution.
+/// - **Lazy path (current implementation)**: `condition_disjunct_holds`
+///   checks whether any **matching** candidate of the condition VS is
+///   positively decided. `cond=2` is never positively decided here, so the
+///   disjunct never holds and the deferred requirement never gets encoded.
+///   `b` is therefore absent from the resolution.
+///
+/// The lazy semantics align with what a human would expect from "if `cond>=2`
+/// is selected": exclusion of `cond=1` is not the same as selection of
+/// `cond=2`.
+///
+/// This test pins the lazy behaviour so any future regression that re-derives
+/// the eager semantics fails loudly.
+#[test]
+#[traced_test]
+fn test_lazy_conditional_externally_excluded_complement_does_not_fire() {
+    let mut provider = BundleBoxProvider::from_packages(&[
+        ("a", 1, vec!["b; if cond 2..3"]),
+        ("b", 1, vec![]),
+        ("cond", 1, vec![]),
+        ("cond", 2, vec![]),
+    ]);
+    // Externally reject the *complement* candidate `cond=1`. Nothing forces
+    // `cond=2` to be selected; the only requirement is on `a`.
+    provider.exclude("cond", 1, "it is externally excluded");
+
+    let requirements = provider.requirements(&["a"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+
+    // `b` must NOT appear in the resolution: the lazy path correctly sees
+    // that `cond=2` (the *matching* candidate of `cond 2..3`) is never
+    // positively decided, so the deferred requirement never fires. The
+    // legacy eager path would have included `b` here -- see the doc-comment
+    // above for the contrast.
+    assert_snapshot!(result, @"a=1");
+
+    // The deferred entry must still be sitting in the map (its disjunct
+    // never held), confirming the lazy path's predicate is what kept `b`
+    // out -- not some unrelated reason like `a` being uninstallable.
+    assert_eq!(
+        solver.deferred_requirements_count(),
+        1,
+        "the `if cond 2..3` disjunct never fired, so its deferred entry \
+         must remain"
+    );
 }
 
 #[cfg(feature = "serde")]

--- a/tests/solver/main.rs
+++ b/tests/solver/main.rs
@@ -778,6 +778,103 @@ fn test_solve_with_soft_requirement_forbid_clause_conflict() {
     "###);
 }
 
+/// Adds an unsolvable, conflict-heavy core: every version of `a` needs a
+/// different exclusive version of `m` than every version of `b`, so the
+/// refutation has to dismiss each version of `a` with a real conflict
+/// (selecting `a=i` propagates `m=i`, which forbids every other `m` version
+/// and with it all of `b`). With enough versions the conflict count crosses
+/// the Luby restart base interval and restarts fire mid-refutation.
+fn add_conflict_heavy_core(provider: &mut BundleBoxProvider, n: u32) {
+    for i in 1..=n {
+        let a_dep = format!("m {i}..{}", i + 1);
+        let b_dep = format!("m {}..{}", i + n, i + n + 1);
+        provider.add_package("a", Pack::new(i), &[a_dep.as_str()], &[]);
+        provider.add_package("b", Pack::new(i), &[b_dep.as_str()], &[]);
+        provider.add_package("m", Pack::new(i), &[], &[]);
+        provider.add_package("m", Pack::new(i + n), &[], &[]);
+    }
+}
+
+/// A refutation that crosses the restart interval must still conclude
+/// unsolvable: a restart lands at the run's root install level without
+/// being mistaken for the conflict-at-root unsolvable case, and the learnt
+/// clauses eventually contradict at that level.
+///
+/// This refutation makes monotonic progress (each `a=i` is permanently
+/// killed by a learnt clause), so every restart fires from a different,
+/// shrinking state. It therefore also pins that the futility gate does not
+/// misfire on a productive run: no signature repeats, so suppression must
+/// stay at zero. (The gate's firing path — a run that *does* revisit a
+/// signature — is an emergent activity-driven cycle seen on the corpus,
+/// e.g. concrete problem 761; it is exercised there rather than by a
+/// synthetic unit test, where cycling does not reliably reproduce.)
+#[test]
+fn test_restarts_during_refutation_keep_the_verdict() {
+    let mut provider = BundleBoxProvider::new();
+    add_conflict_heavy_core(&mut provider, 300);
+
+    let requirements = provider.requirements(&["a", "b"]);
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new().requirements(requirements);
+
+    let result = solver.solve(problem);
+    assert!(
+        matches!(result, Err(UnsolvableOrCancelled::Unsolvable(_))),
+        "the a/b/m core is unsolvable"
+    );
+    #[cfg(feature = "diagnostics")]
+    {
+        assert!(
+            solver.restart_count() >= 1,
+            "a conflict-heavy refutation must cross the restart interval \
+             (got {} restarts)",
+            solver.restart_count()
+        );
+        assert_eq!(
+            solver.restart_suppression_count(),
+            0,
+            "a monotonic refutation makes progress and must not trip the \
+             futility gate"
+        );
+    }
+}
+
+/// The restart floor contract: while a soft requirement is being decided,
+/// the previous solution is preserved prior state below the run's root
+/// install level, and a restart must never undo it. The soft requirement
+/// drags in the conflict-heavy core so restarts fire during its `run_sat`
+/// call; the hard solution must come through untouched and the soft
+/// requirement must simply be excluded.
+#[test]
+fn test_restarts_in_soft_requirement_run_preserve_prior_solution() {
+    let mut provider =
+        BundleBoxProvider::from_packages(&[("app", 1, vec!["lib"]), ("lib", 1, vec![])]);
+    add_conflict_heavy_core(&mut provider, 300);
+    provider.add_package("s", Pack::new(1), &["a", "b"], &[]);
+
+    let requirements = provider.requirements(&["app"]);
+    let extra_solvables = [provider.solvable_id("s", 1)];
+
+    let mut solver = Solver::new(provider);
+    let problem = Problem::new()
+        .requirements(requirements)
+        .soft_requirements(extra_solvables);
+
+    let solved = solver.solve(problem).unwrap();
+    let result = transaction_to_string(solver.provider(), &solved);
+    assert_snapshot!(result, @r###"
+        app=1
+        lib=1
+        "###);
+    #[cfg(feature = "diagnostics")]
+    assert!(
+        solver.restart_count() >= 1,
+        "the soft-requirement run must cross the restart interval \
+         (got {} restarts)",
+        solver.restart_count()
+    );
+}
+
 #[test]
 fn test_solve_with_additional_with_constrains() {
     let mut provider = BundleBoxProvider::from_packages(&[

--- a/tools/solve-snapshot/src/main.rs
+++ b/tools/solve-snapshot/src/main.rs
@@ -37,6 +37,13 @@ struct Opts {
     #[clap(long, default_value = "0")]
     seed: u64,
 
+    /// Skip the first N problems: they are still generated (to advance the
+    /// RNG deterministically) but not solved or recorded. Combined with
+    /// `--seed S -n K+1 --skip K` this replays exactly problem K of the run
+    /// with seed S, e.g. to re-measure an outlier in isolation.
+    #[clap(long, default_value = "0")]
+    skip: usize,
+
     /// Enable tracing output (set RUST_LOG for verbosity, e.g. RUST_LOG=info)
     #[clap(long)]
     tracing: bool,
@@ -118,6 +125,10 @@ fn main() {
                 }
                 _ => unreachable!(),
             }
+        }
+
+        if i < opts.skip {
+            continue;
         }
 
         eprintln!(


### PR DESCRIPTION
This PR adds the classic CDCL restart policy to `run_sat`: after `128 × luby(n)` learnt conflicts the trail is retracted to the run's root install level, keeping all learnt clauses and activity scores, so the search re-descends guided by what the conflicts taught it instead of staying committed to early decisions that predate that knowledge.

**Background**

Without restarts a wrong early decision poisons an entire long proof: the solver grinds tens of thousands of conflicts inside a subtree that a fresh descent with the learnt clauses avoids outright. Restarts are what crack long refutations, and every modern CDCL solver ([MiniSat](https://github.com/niklasso/minisat), [CaDiCaL](https://github.com/arminbiere/cadical), [Glucose](https://www.labri.fr/perso/lsimon/research/glucose/)) ships them; the [Luby sequence](https://www.sciencedirect.com/science/article/pii/0020019093900299) is the textbook universally-optimal pacing.

**Implementation**

* Pacing is per `run_sat` call (base interval 128, campaign-tuned: a 512 sensitivity check kept only half the win on the hard problems and lost ground everywhere else). The retract is a single `restart_to_run_root()` primitive so future restart triggers share one path.
* The retract target is the run's root install level (`starting_level + 1`): a preserved prior solution under a soft requirement is never undone (two tests pin that contract). A restart asserts nothing — single-literal learnt clauses re-apply through the assertion scan, watches handle the rest — and the check runs after `learn_from_conflict`, so unsolvable detection always wins.
* **The futility gate.** A restart that keeps firing from the same state (same conflict level, same trail length) is not redirecting the search: the run is grinding one long contiguous proof that restarts only interrupt, and near the timeout can prevent from ever finishing. One corpus problem cycled through three exact restart states for 270k conflicts without completing, yet finished in 34k once committed — so after four restarts from one signature the run commits and restarts are suppressed until the next `run_sat` call. Productive runs were never observed repeating a signature; the gate fired on 3 of 2000 corpus solves. (This is a blocking-restarts variant à la [Glucose](https://www.ijcai.org/Proceedings/12/Papers/056.pdf), with an exact signal instead of a trail-size average: resolvo cannot phase-save — values are fixed by version preference — so cycling has to be detected, not prevented.)
* Restarts compose with the incremental decide queue (#238) through its sync floor; the optimized-with-assertions decide oracle stayed green over the corpus including the restart-heaviest solves. Diagnostics gain `Restarts` and `Restart suppressions` counters.

**Benchmarks**

Conda-forge snapshot (`tools/solve-snapshot`), seeds 0 and 1, 1000 problems each, 60 s timeout, identical problem sequences, strictly sequential runs against main (`eb6e8df`, which already includes #237 and #238); the branch is rebased on it.

| metric | main | this PR |
|---|---:|---:|
| total solve time (seed 0) | 1085.7 s | **1002.9 s (−7.6%)** |
| total solve time (seed 1) | 890.9 s | **839.8 s (−5.7%)** |
| conflicts (seed 0 / 1) | 346,994 / 187,915 | **238,603 (−31%) / 160,565 (−15%)** |
| p99.5 (seed 0 / 1) | 24.01 s / 17.91 s | **14.58 s (−39%) / 10.95 s (−39%)** |
| p50 (seed 0 / 1) | 0.546 s / 0.480 s | 0.533 s (−2.2%) / 0.477 s (−0.6%) |
| ok / unsat / timeout | 439/559/2 and 459/541/0 | **440/559/1** and 459/541/0 |

The single status difference is in the branch's favor: problem 184 of seed 0 times out on main and completes on the branch in 49 s. Restarts are a tail trade with the costs spread thin: ~84% of solves never fire one and are unaffected; among the ~16% that do, savings outweigh costs ≈ 4.5:1 in seconds (seed 0: 17 solves ≥10% faster totalling −74.7 s vs 10 slower totalling +19.9 s; worst single regression +5.7 s, bounded, non-cycling). The visible edge of that tax is seed 1's p99 (+2.7%, 4.97 s vs 4.84 s) while its p99.5 drops 39%.

Solution drift: restarts reorder exploration, so 2 of 2000 problems resolve to a different but equally valid solution (one bistable cluster picks the newer harfbuzz/icu, the other trades iris 3.11 for matplotlib 3.9); per-decision version preference is unaffected. Documented in the changelog as policy: valid solutions may differ between versions when solver heuristics improve.

<img src="https://raw.githubusercontent.com/baszalmstra/resolvo/58d69693a2705339fd5793f38297137c6efec0e3/luby-restarts-duration-histogram.png" />
<img src="https://raw.githubusercontent.com/baszalmstra/resolvo/58d69693a2705339fd5793f38297137c6efec0e3/luby-restarts-duration-diff-histogram.png" />

Top 5 most-improved problems (this PR vs main):

- `lua53, plant-seg, pygeoops, numba, cosmopharm, google-cloud-...` | **24.51s faster**
- `tf-keras, alibi, cdasws, tip, schedula, esi-utils-io, xonsh,...` | **18.89s faster**
- `apache-airflow-providers-facebook, orange3-bioinformatics, r...` | **15.12s faster**
- `bcj-cffi, exchange-calendars, pyleiden, opentelemetry-instru...` | **14.18s faster**
- `blosc, pyspnego, mpl_table, apscheduler >=3.9.1, prefect-doc...` | **7.33s faster**

Follow-up worth its own investigation: stable re-descent (the requirement-order analogue of phase saving) would let a restarted search resume instead of reshuffle, which should convert the losing fires into near-no-ops and could eventually replace the gate.
